### PR TITLE
Add block prefixes to simplify form theming

### DIFF
--- a/Form/Type/CompletionContactType.php
+++ b/Form/Type/CompletionContactType.php
@@ -47,4 +47,12 @@ class CompletionContactType extends AbstractType
             'validation_groups' => ['completion'],
         ]);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'contact';
+    }
 }

--- a/Form/Type/ProfileAddressType.php
+++ b/Form/Type/ProfileAddressType.php
@@ -50,4 +50,12 @@ class ProfileAddressType extends AbstractType
             ]
         );
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'address';
+    }
 }

--- a/Form/Type/ProfileContactAddressType.php
+++ b/Form/Type/ProfileContactAddressType.php
@@ -44,4 +44,12 @@ class ProfileContactAddressType extends AbstractType
             ]
         );
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'contact_address';
+    }
 }

--- a/Form/Type/ProfileContactType.php
+++ b/Form/Type/ProfileContactType.php
@@ -85,4 +85,12 @@ class ProfileContactType extends AbstractType
             ]
         );
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'contact';
+    }
 }

--- a/Form/Type/RegistrationContactType.php
+++ b/Form/Type/RegistrationContactType.php
@@ -41,4 +41,12 @@ class RegistrationContactType extends AbstractType
             'validation_groups' => ['registration'],
         ]);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'contact';
+    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Set the block prefix for same entities to the same value.

#### Why?

This simplifies the form theming so he can style the a specific field e.g. birthday in registration and profile the same way without copying the code.

#### Example Usage

```twig
{% block contact_row %}
    {{- form_label(form) -}}
    {{- form_errors(form) -}}
    {{- form_widget(form) -}}
{% endblock %}

{% block contact_address_row %}
    {{- form_label(form) -}}
    {{- form_errors(form) -}}
    {{- form_widget(form) -}}
{% endblock %}

{% block address_row %}
    {{- form_label(form) -}}
    {{- form_errors(form) -}}
    {{- form_widget(form) -}}
{% endblock %}
```

When you not set a specific prefix you need to add a block `profile_contact`, `registration_contact`, `completion_contact`, ....
