### PR TITLE
Fix password reset when user has salt

### DIFF
--- a/Controller/AbstractController.php
+++ b/Controller/AbstractController.php
@@ -80,7 +80,11 @@ abstract class AbstractController extends Controller
             return $user;
         }
 
-        $salt = $this->get('sulu_security.salt_generator')->getRandomSalt();
+        $salt = $user->getSalt();
+        if (!$salt) {
+            $salt = $this->get('sulu_security.salt_generator')->getRandomSalt();
+        }
+
         $encoder = $this->get('security.encoder_factory')->getEncoder($user);
         $password = $encoder->encodePassword($plainPassword, $salt);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Do not generate a new salt when password is reseted.

#### Why?

Encoder will use the old salt for generate the new password hash.
