### PR TITLE
Fix completion listener for not cache 302 redirect

### DIFF
--- a/EventListener/CompletionListener.php
+++ b/EventListener/CompletionListener.php
@@ -113,6 +113,7 @@ class CompletionListener
             $completionUrl = $this->router->generate('sulu_community.completion', $uriParameters);
 
             $response = new RedirectResponse($completionUrl);
+            $response->setPrivate();
             $event->setResponse($response);
         }
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Set completion listener redirect header to cache private.

#### Why?

302 Redirects will be cached when public.
