### PR TITLE
Fix registration block after deny over request

### DIFF
--- a/Tests/Unit/Validator/BlockedValidatorTest.php
+++ b/Tests/Unit/Validator/BlockedValidatorTest.php
@@ -27,7 +27,12 @@ class BlockedValidatorTest extends \PHPUnit_Framework_TestCase
 
         $validator->initialize($context->reveal());
         $repository->findBySender('test@sulu.io')
-            ->willReturn([new BlacklistItem('*@sulu.io', BlacklistItem::TYPE_BLOCK)]);
+            ->willReturn(
+                [
+                    new BlacklistItem('*@sulu.io', BlacklistItem::TYPE_REQUEST),
+                    new BlacklistItem('test@sulu.io', BlacklistItem::TYPE_BLOCK),
+                ]
+            );
 
         $validator->validate('test@sulu.io', new Blocked());
 

--- a/Validator/Constraints/BlockedValidator.php
+++ b/Validator/Constraints/BlockedValidator.php
@@ -43,11 +43,9 @@ class BlockedValidator extends ConstraintValidator
         $items = $this->blacklistItemRepository->findBySender($value);
 
         foreach ($items as $item) {
-            if (BlacklistItem::TYPE_BLOCK !== $item->getType()) {
-                return;
+            if (BlacklistItem::TYPE_BLOCK === $item->getType()) {
+                return $this->context->addViolation($constraint->message, ['%email%' => $value]);
             }
-
-            return $this->context->addViolation($constraint->message, ['%email%' => $value]);
         }
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #25
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

Check if one blocked entry exists in validation.

#### Why?

A user can if first entry is just on request.