### PR TITLE
Only check completion listener on safe http methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## dev-develop
 
+ - BUGFIX      #31    fix completion listener listen on none safe methods.
  - ENHANCEMENT #29    translate country names with Symfony Intl.
  - BUGFIX      #30    fix validation for subforms.
  - BUGFIX      #26    remove contact when user is denied.

--- a/EventListener/CompletionListener.php
+++ b/EventListener/CompletionListener.php
@@ -83,7 +83,7 @@ class CompletionListener
         $completionUrl = $this->router->generate('sulu_community.completion');
 
         if (!$event->isMasterRequest()
-            || $request->isMethod('post')
+            || !$request->isMethodSafe()
             || $request->isXmlHttpRequest()
             || $request->getPathInfo() === $completionUrl
             || $request->getPathInfo() === $this->fragmentPath


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Do completion listener redirect only on safe methods.

