### PR TITLE
allow route name and add locale replacer in confirmation redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## dev-develop
 
+ - FEATURE     #33    allow route name and add locale replacer in confirmation redirect 
  - BUGFIX      #31    fix completion listener listen on none safe methods.
  - ENHANCEMENT #29    translate country names with Symfony Intl.
  - BUGFIX      #30    fix validation for subforms.

--- a/Controller/ConfirmationController.php
+++ b/Controller/ConfirmationController.php
@@ -33,6 +33,7 @@ class ConfirmationController extends AbstractController
     public function indexAction(Request $request, $token)
     {
         $communityManager = $this->getCommunityManager($this->getWebspaceKey());
+
         $success = false;
 
         // Confirm user by token
@@ -49,7 +50,13 @@ class ConfirmationController extends AbstractController
             $redirectTo = $communityManager->getConfigTypeProperty(self::TYPE, Configuration::REDIRECT_TO);
 
             if ($redirectTo) {
-                return $this->redirect($redirectTo);
+                if (strpos($redirectTo, '/') === 0) {
+                    $url = str_replace('{localization}', $request->getLocale(), $redirectTo);
+                } else {
+                    $url = $this->get('router')->generate($redirectTo);
+                }
+
+                return $this->redirect($url);
             }
 
             $success = true;

--- a/Tests/app/Resources/webspaces/sulu.io.xml
+++ b/Tests/app/Resources/webspaces/sulu.io.xml
@@ -31,9 +31,6 @@
         <portal>
             <name>Sulu CMF AT</name>
             <key>sulucmf_at</key>
-            <resource-locator>
-                <strategy>tree</strategy>
-            </resource-locator>
 
             <environments>
                 <environment type="prod">


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #32 
| License | MIT

#### What's in this PR?

```yml
# localization replacer
sulu_community:
    webspaces:
        kuechengoetter:
            confirmation:
                redirect_to: /{localization}/completion?confirmed=true
# route name
sulu_community:
    webspaces:
        kuechengoetter:
            confirmation:
                redirect_to: route_name
```