### PR TITLE
Fixed get correct encoder for new salt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## dev-develop
 
+ - BUGFIX      ---    fixed get correct encoder for new salt
  - ENHANCEMENT ---    fixed the caching of completion redirect
  - FEATURE     #34    support for sulu 1.3
  - FEATURE     #33    allow route name and add locale replacer in confirmation redirect 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## dev-develop
 
- - BUGFIX      ---    fixed get correct encoder for new salt
+ - BUGFIX      #39    fixed get correct encoder for new salt
  - ENHANCEMENT ---    fixed the caching of completion redirect
  - FEATURE     #34    support for sulu 1.3
  - FEATURE     #33    allow route name and add locale replacer in confirmation redirect 

--- a/Controller/AbstractController.php
+++ b/Controller/AbstractController.php
@@ -85,11 +85,11 @@ abstract class AbstractController extends Controller
             $salt = $this->get('sulu_security.salt_generator')->getRandomSalt();
         }
 
+        $user->setSalt($salt);
         $encoder = $this->get('security.encoder_factory')->getEncoder($user);
         $password = $encoder->encodePassword($plainPassword, $salt);
 
         $user->setPassword($password);
-        $user->setSalt($salt);
 
         return $user;
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

When is choosen by the salt e.g. use md5 when salt not exist the salt need to be set before choose the encoder.

#### Why?

Else it will return a false encoder and the user can not login.