### PR TITLE
Bugfix/email setting on registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,4 @@ npm-debug.log
 # tests
 Tests/app/cache
 Tests/app/logs
-
+Tests/app/data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 ## dev-develop
 
  - BUGFIX      #43    fix setting of email for user on registration and profile change.
- - BUGFIX      #39    fixed get correct encoder for new salt
- - ENHANCEMENT ---    fixed the caching of completion redirect
+ - BUGFIX      #39    fixed get correct encoder for new salt.
+ - ENHANCEMENT ---    fixed the caching of completion redirect.
  - FEATURE     #34    support for sulu 1.3
- - FEATURE     #33    allow route name and add locale replacer in confirmation redirec
+ - FEATURE     #33    allow route name and add locale replacer in confirmation redirect.
  - BUGFIX      #31    fix completion listener listen on none safe methods.
  - ENHANCEMENT #29    translate country names with Symfony Intl.
  - BUGFIX      #30    fix validation for subforms.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## dev-develop
 
- - BUGFIX      #37    fix setting of email for user on registration.
+ - BUGFIX      #43    fix setting of email for user on registration and profile change.
  - BUGFIX      #39    fixed get correct encoder for new salt
  - ENHANCEMENT ---    fixed the caching of completion redirect
  - FEATURE     #34    support for sulu 1.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## dev-develop
 
+ - BUGFIX      #37    fix setting of email for user on registration.
  - ENHANCEMENT #29    translate country names with Symfony Intl.
  - BUGFIX      #30    fix validation for subforms.
  - BUGFIX      #26    remove contact when user is denied.

--- a/Controller/EmailConfirmationController.php
+++ b/Controller/EmailConfirmationController.php
@@ -39,6 +39,8 @@ class EmailConfirmationController extends AbstractController
         if ($token !== null) {
             $user = $token->getUser();
             $user->setEmail($user->getContact()->getMainEmail());
+            $userContact = $user->getContact();
+            $userContact->getEmails()[0]->setEmail($userContact->getMainEmail());
             $this->get('doctrine.orm.entity_manager')->remove($token);
             $this->saveEntities();
 

--- a/Controller/EmailConfirmationController.php
+++ b/Controller/EmailConfirmationController.php
@@ -42,13 +42,11 @@ class EmailConfirmationController extends AbstractController
             $user->setEmail($user->getContact()->getMainEmail());
             $userContact = $user->getContact();
             if (count($userContact->getEmails() === 0) {
-                $emailType = $entityManager
-                    ->getRepository(self::$emailTypeEntityName)
-                    ->findAll();
+                $emailType = $this->entityManager->getReference(EmailType::class, 1);
 
                 $contactEmail = new Email();
                 $contactEmail->setEmail($user->getContact()->getMainEmail());
-                $contactEmail->setEmailType($emailType[0]);
+                $contactEmail->setEmailType($emailType);
                 $userContact->addEmail($contactEmail);
             }
             $userContact->getEmails()->first()->setEmail($userContact->getMainEmail());

--- a/Controller/EmailConfirmationController.php
+++ b/Controller/EmailConfirmationController.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\CommunityBundle\Controller;
 
 use Sulu\Bundle\CommunityBundle\DependencyInjection\Configuration;
+use Sulu\Bundle\ContactBundle\Entity\EmailType;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/Controller/EmailConfirmationController.php
+++ b/Controller/EmailConfirmationController.php
@@ -40,7 +40,7 @@ class EmailConfirmationController extends AbstractController
             $user = $token->getUser();
             $user->setEmail($user->getContact()->getMainEmail());
             $userContact = $user->getContact();
-            $userContact->getEmails()[0]->setEmail($userContact->getMainEmail());
+            $userContact->getEmails()->first()->setEmail($userContact->getMainEmail());
             $this->get('doctrine.orm.entity_manager')->remove($token);
             $this->saveEntities();
 

--- a/Controller/EmailConfirmationController.php
+++ b/Controller/EmailConfirmationController.php
@@ -42,7 +42,7 @@ class EmailConfirmationController extends AbstractController
             $user = $token->getUser();
             $user->setEmail($user->getContact()->getMainEmail());
             $userContact = $user->getContact();
-            if (count($userContact->getEmails() === 0) {
+            if (count($userContact->getEmails()) === 0) {
                 $emailType = $entityManager->getReference(EmailType::class, 1);
 
                 $contactEmail = new Email();

--- a/Controller/EmailConfirmationController.php
+++ b/Controller/EmailConfirmationController.php
@@ -42,7 +42,7 @@ class EmailConfirmationController extends AbstractController
             $user->setEmail($user->getContact()->getMainEmail());
             $userContact = $user->getContact();
             if (count($userContact->getEmails() === 0) {
-                $emailType = $this->entityManager->getReference(EmailType::class, 1);
+                $emailType = $entityManager->getReference(EmailType::class, 1);
 
                 $contactEmail = new Email();
                 $contactEmail->setEmail($user->getContact()->getMainEmail());

--- a/Manager/UserManager.php
+++ b/Manager/UserManager.php
@@ -114,13 +114,11 @@ class UserManager implements UserManagerInterface
             $contact->setLastName('');
         }
 
-        $emailType = $this->entityManager
-            ->getRepository($this->entityManager->getReference(EmailType::class, 1))
-            ->findAll();
+        $emailType = $this->entityManager->getReference(EmailType::class, 1);
 
         $contactEmail = new Email();
         $contactEmail->setEmail($user->getEmail());
-        $contactEmail->setEmailType($emailType[0]);
+        $contactEmail->setEmailType($emailType);
         $contact->addEmail($contactEmail);
         $contact->setMainEmail($user->getEmail());
 

--- a/Manager/UserManager.php
+++ b/Manager/UserManager.php
@@ -29,8 +29,6 @@ use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
  */
 class UserManager implements UserManagerInterface
 {
-    protected static $emailTypeEntityName = 'SuluContactBundle:EmailType';
-
     /**
      * @var EntityManagerInterface
      */
@@ -117,7 +115,7 @@ class UserManager implements UserManagerInterface
         }
 
         $emailType = $this->entityManager
-            ->getRepository(self::$emailTypeEntityName)
+            ->getRepository($this->entityManager->getReference(EmailType::class, 1))
             ->findAll();
 
         $contactEmail = new Email();

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -36,7 +36,7 @@
             <argument type="service" id="sulu.repository.user"/>
             <argument type="service" id="sulu.repository.role"/>
             <argument type="service" id="sulu.repository.contact"/>
-            <argument type="service" id="sulu_community.mail_factory"/>
+            <argument type="service" id="sulu_contact.contact_manager"/>
         </service>
 
         <!-- mail-listener -->

--- a/Tests/Functional/Controller/EmailConfirmationControllerTest.php
+++ b/Tests/Functional/Controller/EmailConfirmationControllerTest.php
@@ -33,15 +33,15 @@ class EmailConfirmationControllerTest extends SuluTestCase
 
         $this->purgeDatabase();
 
-        $contactTypes = new LoadDefaultTypes();
-        $contactTypes->load($this->entityManager);
-
         /** @var EntityManagerInterface $entityManager */
         $entityManager = $this->getEntityManager();
 
+        $contactTypes = new LoadDefaultTypes();
+        $contactTypes->load($entityManager);
+
         $mainEmailAddress = 'new@sulu.io';
 
-        $emailType = $this->entityManager->getReference(EmailType::class, 1);
+        $emailType = $entityManager->getReference(EmailType::class, 1);
 
         $contactEmail = new Email();
         $contactEmail->setEmail($mainEmailAddress);

--- a/Tests/Functional/Controller/EmailConfirmationControllerTest.php
+++ b/Tests/Functional/Controller/EmailConfirmationControllerTest.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\CommunityBundle\Tests\Functional\Controller;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Bundle\CommunityBundle\Entity\EmailConfirmationToken;
+use Sulu\Bundle\ContactBundle\DataFixtures\ORM\LoadDefaultTypes;
 use Sulu\Bundle\ContactBundle\Entity\Contact;
 use Sulu\Bundle\ContactBundle\Entity\Email;
 use Sulu\Bundle\ContactBundle\Entity\EmailType;

--- a/Tests/Functional/Controller/EmailConfirmationControllerTest.php
+++ b/Tests/Functional/Controller/EmailConfirmationControllerTest.php
@@ -38,13 +38,11 @@ class EmailConfirmationControllerTest extends SuluTestCase
 
         $mainEmailAddress = 'new@sulu.io';
 
-        $emailType = $entityManager
-            ->getRepository(self::$emailTypeEntityName)
-            ->findAll();
+        $emailType = $entityManager->getReference(EmailType::class, 1);
 
         $contactEmail = new Email();
         $contactEmail->setEmail($mainEmailAddress);
-        $contactEmail->setEmailType($emailType[0]);
+        $contactEmail->setEmailType($emailType);
 
         $contact = new Contact();
         $contact->setMainEmail($mainEmailAddress);

--- a/Tests/Functional/Controller/EmailConfirmationControllerTest.php
+++ b/Tests/Functional/Controller/EmailConfirmationControllerTest.php
@@ -34,6 +34,9 @@ class EmailConfirmationControllerTest extends SuluTestCase
 
         $this->purgeDatabase();
 
+        $contactTypes = new LoadDefaultTypes();
+        $contactTypes->load($this->entityManager);
+
         /** @var EntityManagerInterface $entityManager */
         $entityManager = $this->getEntityManager();
 

--- a/Tests/Functional/Controller/EmailConfirmationControllerTest.php
+++ b/Tests/Functional/Controller/EmailConfirmationControllerTest.php
@@ -22,8 +22,6 @@ use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 
 class EmailConfirmationControllerTest extends SuluTestCase
 {
-    protected static $emailTypeEntityName = 'SuluContactBundle:EmailType';
-
     /**
      * @var User
      */
@@ -43,7 +41,7 @@ class EmailConfirmationControllerTest extends SuluTestCase
 
         $mainEmailAddress = 'new@sulu.io';
 
-        $emailType = $entityManager->getReference(EmailType::class, 1);
+        $emailType = $this->entityManager->getReference(EmailType::class, 1);
 
         $contactEmail = new Email();
         $contactEmail->setEmail($mainEmailAddress);

--- a/Tests/Functional/Controller/EmailConfirmationControllerTest.php
+++ b/Tests/Functional/Controller/EmailConfirmationControllerTest.php
@@ -13,7 +13,6 @@ namespace Sulu\Bundle\CommunityBundle\Tests\Functional\Controller;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Bundle\CommunityBundle\Entity\EmailConfirmationToken;
-use Sulu\Bundle\ContactBundle\DataFixtures\ORM\LoadDefaultTypes;
 use Sulu\Bundle\ContactBundle\Entity\Contact;
 use Sulu\Bundle\ContactBundle\Entity\Email;
 use Sulu\Bundle\ContactBundle\Entity\EmailType;

--- a/Tests/Functional/Controller/EmailConfirmationControllerTest.php
+++ b/Tests/Functional/Controller/EmailConfirmationControllerTest.php
@@ -39,7 +39,11 @@ class EmailConfirmationControllerTest extends SuluTestCase
 
         $mainEmailAddress = 'new@sulu.io';
 
-        $emailType = $entityManager->getReference(EmailType::class, 1);
+        // $emailType = $entityManager->getReference(EmailType::class, 1);
+
+        $emailType = $entityManager
+            ->getRepository(self::$emailTypeEntityName)
+            ->findAll();
 
         $contactEmail = new Email();
         $contactEmail->setEmail($mainEmailAddress);

--- a/Tests/Functional/Controller/EmailConfirmationControllerTest.php
+++ b/Tests/Functional/Controller/EmailConfirmationControllerTest.php
@@ -47,7 +47,7 @@ class EmailConfirmationControllerTest extends SuluTestCase
 
         $contactEmail = new Email();
         $contactEmail->setEmail($mainEmailAddress);
-        $contactEmail->setEmailType($emailType);
+        $contactEmail->setEmailType($emailType[0]);
 
         $contact = new Contact();
         $contact->setMainEmail($mainEmailAddress);

--- a/Tests/Functional/Controller/EmailConfirmationControllerTest.php
+++ b/Tests/Functional/Controller/EmailConfirmationControllerTest.php
@@ -39,15 +39,11 @@ class EmailConfirmationControllerTest extends SuluTestCase
 
         $mainEmailAddress = 'new@sulu.io';
 
-        // $emailType = $entityManager->getReference(EmailType::class, 1);
-
-        $emailType = $entityManager
-            ->getRepository(self::$emailTypeEntityName)
-            ->findAll();
+        $emailType = $entityManager->getReference(EmailType::class, 1);
 
         $contactEmail = new Email();
         $contactEmail->setEmail($mainEmailAddress);
-        $contactEmail->setEmailType($emailType[0]);
+        $contactEmail->setEmailType($emailType);
 
         $contact = new Contact();
         $contact->setMainEmail($mainEmailAddress);

--- a/Tests/Functional/Controller/EmailConfirmationControllerTest.php
+++ b/Tests/Functional/Controller/EmailConfirmationControllerTest.php
@@ -36,12 +36,12 @@ class EmailConfirmationControllerTest extends SuluTestCase
         /** @var EntityManagerInterface $entityManager */
         $entityManager = $this->getEntityManager();
 
-        $contactTypes = new LoadDefaultTypes();
-        $contactTypes->load($entityManager);
-
         $mainEmailAddress = 'new@sulu.io';
 
-        $emailType = $entityManager->getReference(EmailType::class, 1);
+        $emailType = new EmailType();
+        $emailType->setName('email.work');
+        $emailType->setId(1);
+        $entityManager->persist($emailType);
 
         $contactEmail = new Email();
         $contactEmail->setEmail($mainEmailAddress);
@@ -52,7 +52,6 @@ class EmailConfirmationControllerTest extends SuluTestCase
         $contact->setFirstName('Hikaru');
         $contact->setLastName('Sulu');
         $contact->addEmail($contactEmail);
-
 
         $entityManager->persist($contact);
         $entityManager->flush();

--- a/Tests/Functional/Controller/EmailConfirmationControllerTest.php
+++ b/Tests/Functional/Controller/EmailConfirmationControllerTest.php
@@ -20,6 +20,8 @@ use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 
 class EmailConfirmationControllerTest extends SuluTestCase
 {
+    protected static $emailTypeEntityName = 'SuluContactBundle:EmailType';
+
     /**
      * @var User
      */
@@ -35,6 +37,10 @@ class EmailConfirmationControllerTest extends SuluTestCase
         $entityManager = $this->getEntityManager();
 
         $mainEmailAddress = 'new@sulu.io';
+
+        $emailType = $entityManager
+            ->getRepository(self::$emailTypeEntityName)
+            ->findAll();
 
         $contactEmail = new Email();
         $contactEmail->setEmail($mainEmailAddress);

--- a/Tests/Functional/Controller/EmailConfirmationControllerTest.php
+++ b/Tests/Functional/Controller/EmailConfirmationControllerTest.php
@@ -15,6 +15,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Bundle\CommunityBundle\Entity\EmailConfirmationToken;
 use Sulu\Bundle\ContactBundle\Entity\Contact;
 use Sulu\Bundle\ContactBundle\Entity\Email;
+use Sulu\Bundle\ContactBundle\Entity\EmailType;
 use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 

--- a/Tests/Functional/Controller/EmailConfirmationControllerTest.php
+++ b/Tests/Functional/Controller/EmailConfirmationControllerTest.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\CommunityBundle\Tests\Functional\Controller;
 use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Bundle\CommunityBundle\Entity\EmailConfirmationToken;
 use Sulu\Bundle\ContactBundle\Entity\Contact;
+use Sulu\Bundle\ContactBundle\Entity\Email;
 use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 
@@ -33,16 +34,24 @@ class EmailConfirmationControllerTest extends SuluTestCase
         /** @var EntityManagerInterface $entityManager */
         $entityManager = $this->getEntityManager();
 
+        $mainEmailAddress = 'new@sulu.io';
+
+        $contactEmail = new Email();
+        $contactEmail->setEmail($mainEmailAddress);
+        $contactEmail->setEmailType($emailType[0]);
+
         $contact = new Contact();
-        $contact->setMainEmail('new@sulu.io');
+        $contact->setMainEmail($mainEmailAddress);
         $contact->setFirstName('Hikaru');
         $contact->setLastName('Sulu');
+        $contact->addEmail($contactEmail);
+
 
         $entityManager->persist($contact);
         $entityManager->flush();
 
         $this->user = new User();
-        $this->user->setEmail('test@sulu.io');
+        $this->user->setEmail($mainEmailAddress);
         $this->user->setUsername('test');
         $this->user->setPassword('test');
         $this->user->setSalt('test');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Fixes of the setting of the users email address on the contact Email with respective emailType.
Additionally added necessary changes for profile changes of the users email address.

#### Why?

If a contact was edited in the Sulu backoffice, the mainEmail was deleted from the contact. That was because of a missing Email entity that needs to be created on registration and changed on email address changes through the users profile.
