### PR TITLE
Added testcase for email-confirmation if user has no email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## dev-develop
 
+ - BUGFIX      #44    added use statement to fix email-confirmation controller
  - BUGFIX      #43    fix setting of email for user on registration and profile change.
  - BUGFIX      #39    fixed get correct encoder for new salt.
  - ENHANCEMENT ---    fixed the caching of completion redirect.


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

There was an error when the user has no email (fixed by commit https://github.com/sulu/SuluCommunityBundle/commit/7e58a93c25c1efd66c4496397ea2f23698720ee2)