### PR TITLE
Change profile avatar title from fullname to username

### DIFF
--- a/Controller/ProfileController.php
+++ b/Controller/ProfileController.php
@@ -113,7 +113,7 @@ class ProfileController extends AbstractController
             [
                 'id' => (null !== $avatar ? $avatar->getId() : null),
                 'locale' => $locale,
-                'title' => $user->getFullName(),
+                'title' => $user->getUsername(),
                 'collection' => $collection,
             ],
             $user->getId()

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,28 @@
+# Upgrade
+
+## 0.2.0
+
+### Avatar title will use username instead of fullname
+
+If you want this also for old uploaded profile images the username as
+media title run the following sql statement. Attention this will 
+overwrite all manual changed media titles of contact images.
+
+```sql
+UPDATE me_file_version_meta AS fvm
+INNER JOIN me_file_versions AS fv ON 
+    fvm.idFileVersions = fv.id
+INNER JOIN me_files AS f ON
+    fv.idFiles = f.id
+INNER JOIN me_media AS m ON
+    f.idMedia = m.id
+INNER JOIN me_collections AS co ON
+    m.idCollections = co.id
+INNER JOIN co_contacts AS c ON
+    m.id = c.avatar
+INNER JOIN se_users AS u ON
+    u.idContacts = c.id
+SET fvm.title = u.username
+WHERE co.collection_key = 'sulu_contact.contact' AND u.id IS NOT NULL;
+```
+


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| License | MIT

#### What's in this PR?

Change fullname to username in media upload.

#### Why?

Privacy!

#### BC Breaks/Deprecations

When uploaded a profile picture the filename will be the username not the fullname now.

#### To Do

- [x] Migration SQL