### PR TITLE
Also make name in emailadresses configurable

### DIFF
--- a/DependencyInjection/CompilerPass/CommunityManagerCompilerPass.php
+++ b/DependencyInjection/CompilerPass/CommunityManagerCompilerPass.php
@@ -41,19 +41,17 @@ class CommunityManagerCompilerPass implements CompilerPassInterface
 
             if (isset($webspaceConfig[Configuration::EMAIL_FROM])) {
                 $webspaceConfig[Configuration::EMAIL_FROM] = [
-                    $webspaceConfig[Configuration::EMAIL_FROM][Configuration::EMAIL_FROM_EMAIL] => $webspaceConfig[Configuration::EMAIL_FROM][Configuration::EMAIL_FROM_NAME]
+                    $webspaceConfig[Configuration::EMAIL_FROM][Configuration::EMAIL_FROM_EMAIL] => $webspaceConfig[Configuration::EMAIL_FROM][Configuration::EMAIL_FROM_NAME],
                 ];
-            }
-            else {
+            } else {
                 $webspaceConfig[Configuration::EMAIL_FROM] = null;
             }
 
             if (isset($webspaceConfig[Configuration::EMAIL_TO])) {
                 $webspaceConfig[Configuration::EMAIL_TO] = [
-                    $webspaceConfig[Configuration::EMAIL_TO][Configuration::EMAIL_TO_EMAIL] => $webspaceConfig[Configuration::EMAIL_TO][Configuration::EMAIL_TO_NAME]
+                    $webspaceConfig[Configuration::EMAIL_TO][Configuration::EMAIL_TO_EMAIL] => $webspaceConfig[Configuration::EMAIL_TO][Configuration::EMAIL_TO_NAME],
                 ];
-            }
-            else {
+            } else {
                 $webspaceConfig[Configuration::EMAIL_TO] = null;
             }
 

--- a/DependencyInjection/CompilerPass/CommunityManagerCompilerPass.php
+++ b/DependencyInjection/CompilerPass/CommunityManagerCompilerPass.php
@@ -39,6 +39,24 @@ class CommunityManagerCompilerPass implements CompilerPassInterface
                 $webspaceConfig[Configuration::ROLE] = ucfirst($webspaceKey) . 'User';
             }
 
+            if (isset($webspaceConfig[Configuration::EMAIL_FROM])) {
+                $webspaceConfig[Configuration::EMAIL_FROM] = [
+                    $webspaceConfig[Configuration::EMAIL_FROM][Configuration::EMAIL_FROM_EMAIL] => $webspaceConfig[Configuration::EMAIL_FROM][Configuration::EMAIL_FROM_NAME]
+                ];
+            }
+            else {
+                $webspaceConfig[Configuration::EMAIL_FROM] = null;
+            }
+
+            if (isset($webspaceConfig[Configuration::EMAIL_TO])) {
+                $webspaceConfig[Configuration::EMAIL_TO] = [
+                    $webspaceConfig[Configuration::EMAIL_TO][Configuration::EMAIL_TO_EMAIL] => $webspaceConfig[Configuration::EMAIL_TO][Configuration::EMAIL_TO_NAME]
+                ];
+            }
+            else {
+                $webspaceConfig[Configuration::EMAIL_TO] = null;
+            }
+
             $webspaceConfig[Configuration::WEBSPACE_KEY] = $webspaceKey;
 
             $definition = new DefinitionDecorator('sulu_community.community_manager');

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -30,7 +30,11 @@ class Configuration implements ConfigurationInterface
 
     // Basic Webspace configuration
     const EMAIL_FROM = 'from';
+    const EMAIL_FROM_NAME = 'name';
+    const EMAIL_FROM_EMAIL = 'email';
     const EMAIL_TO = 'to';
+    const EMAIL_TO_NAME = 'name';
+    const EMAIL_TO_EMAIL = 'email';
     const ROLE = 'role';
     const WEBSPACE_KEY = 'webspace_key';
     const FIREWALL = 'firewall';
@@ -93,8 +97,36 @@ class Configuration implements ConfigurationInterface
                     ->prototype('array')
                         ->children()
                             // Basic Webspace Configuration
-                            ->scalarNode(self::EMAIL_FROM)->defaultValue(null)->end()
-                            ->scalarNode(self::EMAIL_TO)->defaultValue(null)->end()
+                            ->arrayNode(self::EMAIL_FROM)
+                                ->children()
+                                    ->scalarNode(self::EMAIL_FROM_NAME)->defaultValue(null)->end()
+                                    ->scalarNode(self::EMAIL_FROM_EMAIL)->defaultValue(null)->end()
+                                ->end()
+                                ->beforeNormalization()
+                                ->ifString()
+                                    ->then(function($value) {
+                                        return [
+                                            self::EMAIL_FROM_NAME => $value,
+                                            self::EMAIL_FROM_EMAIL => $value,
+                                        ];
+                                    })
+                                ->end()
+                            ->end()
+                            ->arrayNode(self::EMAIL_TO)
+                                ->children()
+                                    ->scalarNode(self::EMAIL_TO_NAME)->defaultValue(null)->end()
+                                    ->scalarNode(self::EMAIL_TO_EMAIL)->defaultValue(null)->end()
+                                ->end()
+                                ->beforeNormalization()
+                                ->ifString()
+                                    ->then(function($value) {
+                                        return [
+                                            self::EMAIL_TO_NAME => $value,
+                                            self::EMAIL_TO_EMAIL => $value,
+                                        ];
+                                    })
+                                ->end()
+                            ->end()
                             ->scalarNode(self::ROLE)->defaultValue(null)->end()
                             ->scalarNode(self::FIREWALL)->defaultValue(null)->end()
                             // Login

--- a/Mail/Mail.php
+++ b/Mail/Mail.php
@@ -21,8 +21,8 @@ class Mail
     /**
      * Get mail settings for specific type.
      *
-     * @param string $from
-     * @param string $to
+     * @param string|array $from
+     * @param string|array $to
      * @param array $config
      *
      * @return Mail
@@ -39,12 +39,12 @@ class Mail
     }
 
     /**
-     * @var string
+     * @var string|array
      */
     private $from;
 
     /**
-     * @var string
+     * @var string|array
      */
     private $to;
 
@@ -69,8 +69,8 @@ class Mail
     private $adminTemplate;
 
     /**
-     * @param string $from
-     * @param string $to
+     * @param string|array $from
+     * @param string|array $to
      * @param string $subject
      * @param null|string $userTemplate
      * @param null|string $adminTemplate
@@ -87,7 +87,7 @@ class Mail
     /**
      * Returns from.
      *
-     * @return string
+     * @return string|array
      */
     public function getFrom()
     {
@@ -97,7 +97,7 @@ class Mail
     /**
      * Returns to.
      *
-     * @return string
+     * @return string|array
      */
     public function getTo()
     {

--- a/Resources/doc/2-setup-webspace.md
+++ b/Resources/doc/2-setup-webspace.md
@@ -22,7 +22,9 @@ Enable community features for your webspace:
 sulu_community:
     webspaces:
         <webspace_key>:
-            from: %from_email%
+            from:
+                name: 'Website'
+                email: %from_email%
 ```
 
 ## Enable Security

--- a/Resources/doc/3-customization.md
+++ b/Resources/doc/3-customization.md
@@ -11,8 +11,12 @@ sulu_community:
         refresh_interval: 600
     webspaces:
         <webspace_key>:
-            from: %sulu_admin.email%
-            to: %sulu_admin.email%
+            from:
+                name: 'Website'
+                email: %sulu_admin.email%
+            to:
+                name: 'Admin'
+                email: %sulu_admin.email%
             role: CustomRoleName
             firewall: CustomFirewallName
 

--- a/Tests/Unit/Listener/BlacklistListenerTest.php
+++ b/Tests/Unit/Listener/BlacklistListenerTest.php
@@ -77,8 +77,8 @@ class BlacklistListenerTest extends \PHPUnit_Framework_TestCase
 
         $event = $this->prophesize(CommunityEvent::class);
         $event->getConfigProperty(Configuration::WEBSPACE_KEY)->willReturn('sulu_io');
-        $event->getConfigProperty(Configuration::EMAIL_TO)->willReturn('admin@sulu.io');
-        $event->getConfigProperty(Configuration::EMAIL_FROM)->willReturn('from@sulu.io');
+        $event->getConfigProperty(Configuration::EMAIL_TO)->willReturn(['admin@sulu.io' => 'admin@sulu.io']);
+        $event->getConfigProperty(Configuration::EMAIL_FROM)->willReturn(['from@sulu.io' => 'from@sulu.io']);
         $event->getConfigTypeProperty(Configuration::TYPE_BLACKLISTED, Configuration::EMAIL)->willReturn(
             [
                 Configuration::EMAIL_SUBJECT => 'subject',


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #52 
| Related issues/PRs | -
| License | MIT
| Documentation PR | in this PR

#### What's in this PR?

This PR makes it possible to also configure the name in the emails sent by the system

So instead of configuring:
```yml
sulu_community:
    webspaces:
        <webspace_name>:
            from: test@example.com
            to: test@example.com
```

This is also possible (and documented to do it this way):
```yml
sulu_community:
    webspaces:
        <webspace_name>:
            from: 
                name: Test
                email: test@example.com
            to: 
                name: Test
                email: test@example.com
```

#### Why?

It fixes #52 and makes e-mails sent by the system look nicer in the users inbox.

#### Example Usage

See above

#### BC Breaks/Deprecations

None

#### To Do

-
