### PR TITLE
Update RegistrationType.php

### DIFF
--- a/Form/Type/RegistrationType.php
+++ b/Form/Type/RegistrationType.php
@@ -47,7 +47,7 @@ class RegistrationType extends AbstractType
 
         $builder->add(
             'contact',
-            new $options['contact_type'](),
+            RegistrationContactType::class,
             $options['contact_type_options']
         );
 


### PR DESCRIPTION
For fixing the below error. it should be RegistrationContactType::class (this is string) instead of the current code new $options['contact_type']() (This is object)

Uncaught PHP Exception Symfony\Component\Form\Exception\UnexpectedTypeException: "Expected argument of type "string", "Sulu\Bundle\CommunityBundle\Form\Type\RegistrationContactType" given" at /var/www/html/musubiweb/vendor/symfony/symfony/src/Symfony/Component/Form/FormFactory.php line 71 {"exception":"[object] (Symfony\\Component\\Form\\Exception\\UnexpectedTypeException(code: 0): Expected argument of type \"string\", \"Sulu\\Bundle\\CommunityBundle\\Form\\Type\\RegistrationContactType\" given at /var/www/html/musubiweb/vendor/symfony/symfony/src/Symfony/Component/Form/FormFactory.php:71)"} []

| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Explain the contents of the PR.

#### Why?

Which problem does the PR fix? (remove this section if you linked an issue above)

#### Example Usage

~~~php
// If you added new features, show examples of how to use them here
// (remove this section if not a new feature)

$foo = new Foo();

// Now we can do
$foo->doSomething();
~~~

#### BC Breaks/Deprecations

Describe BC breaks/deprecations here. (remove this section if not needed)

#### To Do

- [ ] Create a documentation PR
