### PR TITLE
Removed class construction for sub-types

### DIFF
--- a/Form/Type/CompletionType.php
+++ b/Form/Type/CompletionType.php
@@ -41,7 +41,7 @@ class CompletionType extends AbstractType
 
         $builder->add(
             'contact',
-            new $options['contact_type'](),
+            $options['contact_type'],
             array_merge(
                 $options['contact_type_options'],
                 [

--- a/Form/Type/ProfileContactAddressType.php
+++ b/Form/Type/ProfileContactAddressType.php
@@ -24,7 +24,7 @@ class ProfileContactAddressType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('address', new $options['address_type'](), $options['address_type_options']);
+        $builder->add('address', $options['address_type'], $options['address_type_options']);
         $builder->add('main', HiddenType::class, [
             'required' => false,
             'data' => 1,

--- a/Form/Type/RegistrationType.php
+++ b/Form/Type/RegistrationType.php
@@ -47,7 +47,7 @@ class RegistrationType extends AbstractType
 
         $builder->add(
             'contact',
-            new $options['contact_type'](),
+            $options['contact_type'],
             $options['contact_type_options']
         );
 

--- a/Resources/doc/11-completion.md
+++ b/Resources/doc/11-completion.md
@@ -131,7 +131,7 @@ class CompletionType extends AbstractType
 
         $builder->add(
             'contact',
-            new $options['contact_type'](),
+            $options['contact_type'],
             array_merge(
                 $options['contact_type_options'],
                 [

--- a/Resources/doc/5-registration.md
+++ b/Resources/doc/5-registration.md
@@ -102,7 +102,7 @@ class RegistrationType extends AbstractType
 
         $builder->add(
             'contact',
-            new $options['contact_type'](),
+            $options['contact_type'],
             $options['contact_type_options']
         );
 

--- a/Resources/doc/9-profile.md
+++ b/Resources/doc/9-profile.md
@@ -259,7 +259,7 @@ class ProfileContactAddressType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('address', new $options['address_type'](), $options['address_type_options']);
+        $builder->add('address', $options['address_type'], $options['address_type_options']);
         $builder->add('main', 'hidden', [
             'required' => false,
             'data' => 1,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

When using this bundle with symfony 3.3 it throws an exception because the sub-types has to be full-qualified-classes.