### PR TITLE
Bugfix/fix for sf3 incompatibel formtype properties

### DIFF
--- a/Form/Type/ProfileAddressType.php
+++ b/Form/Type/ProfileAddressType.php
@@ -42,7 +42,7 @@ class ProfileAddressType extends AbstractType
             EntityType::class,
             [
                 'class' => Country::class,
-                'property' => function (Country $country) {
+                'choice_label' => function (Country $country) {
                     return Intl::getRegionBundle()->getCountryName($country->getCode());
                 },
             ]

--- a/Form/Type/ProfileContactType.php
+++ b/Form/Type/ProfileContactType.php
@@ -54,8 +54,8 @@ class ProfileContactType extends AbstractType
             CollectionType::class,
             [
                 'label' => false,
-                'type' => $options['contact_address_type'],
-                'options' => $options['contact_address_type_options'],
+                'entry_type' => $options['contact_address_type'],
+                'entry_options' => $options['contact_address_type_options'],
             ]
         );
         $builder->add(
@@ -63,8 +63,8 @@ class ProfileContactType extends AbstractType
             CollectionType::class,
             [
                 'label' => false,
-                'type' => $options['note_type'],
-                'options' => $options['note_type_options'],
+                'entry_type' => $options['note_type'],
+                'entry_options' => $options['note_type_options'],
             ]
         );
     }

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^5.5 || ^7.0",
+        "symfony/symfony": "^2.8.7 || ^3.0",
         "sulu/sulu": "^1.3 || dev-develop",
         "beberlei/DoctrineExtensions": "^1.0"
     },


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | yes, with Symfony 2.7
| Deprecations? | no
| License | MIT

#### What's in this PR?

Some used options for two formfield types were not compatible with symphony 3. There are changed. 

Details:
CollectionType: `type` is now `entry_type`
CollectionType:  `options` is now `options_type`
These changes break bc with sf2.7.
See: https://symfony.com/doc/current/reference/forms/types/collection.html

EntityType: `property` is now `choice_label`
See: https://symfony.com/doc/current/reference/forms/types/entity.html

Added Symfony compatibility requirement in the composer.json: "symfony/symfony": "^2.8.7 || ^3.0",


#### Why?

UndefinedOptionsException was thrown in SF3.

#### BC Breaks/Deprecations

Changes break with SF2.7