### PR TITLE
Add documentation for client side cache headers

### DIFF
--- a/Resources/doc/4-login.md
+++ b/Resources/doc/4-login.md
@@ -36,6 +36,18 @@ framework:
 })) }}
 ```
 
+Sulu sets by default the cache control header to 240 seconds. So it could happen
+that the browser cache the page and show an incorrect status. For this you can
+decrease or deactivate the browser cache lifetime in `app/config/config.yml`:
+
+```yml
+sulu_http_cache:
+    handlers:
+        public:
+            max_age: 0
+            shared_max_age: 0
+```
+
 **Example Template**:
 
 ```twig


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #40
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Add sulu http cache header configuration to documentation.

#### Why?

Its needed to avoid a that the login-embed shows a cached version in the browser after successfully logout.