### PR TITLE
confirm and enable user also with password reset email

### DIFF
--- a/Manager/CommunityManager.php
+++ b/Manager/CommunityManager.php
@@ -233,6 +233,7 @@ class CommunityManager implements CommunityManagerInterface
     {
         $user->setPasswordResetTokenExpiresAt(null);
         $user->setPasswordResetToken(null);
+        $user->setEnabled(true);
 
         // Event
         $event = new CommunityEvent($user, $this->config);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #28
| License | MIT

#### What's in this PR?

Enable the user on password reset.

#### Why?

When a user did forgot to confirm his email address this is currently. He can currently send himself a password reset email. That he can correctly use the system we need to enable him as with the password reset email he did also confirm his identity.