### PR TITLE
Add bundle version to github template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,6 +2,7 @@
 | --- | ---
 | Bug? | no
 | New Feature? | no
+| Community Bundle Version | Specific version or SHA of commit
 | Sulu Version | Specific version or SHA of a commit
 | Browser Version | Browser name and version
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Add bundle version to github issue template.

#### Why?

To get the sulu version and the bundle version for issues.