### PR TITLE
Add maintenance mode

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,6 @@
 | Fixed tickets | fixes #issuenum
 | Related issues/PRs | #issuenum
 | License | MIT
-| Documentation PR | sulu/sulu-docs#prnum
 
 #### What's in this PR?
 
@@ -35,4 +34,5 @@ Describe BC breaks/deprecations here. (remove this section if not needed)
 
 #### To Do
 
-- [ ] Create a documentation PR
+- [ ] Add Documentation
+

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -13,3 +13,4 @@ disabled:
     - blankline_after_open_tag
     - function_declaration
     - single_line_class_definition
+    - const_separation

--- a/Controller/LoginController.php
+++ b/Controller/LoginController.php
@@ -57,7 +57,14 @@ class LoginController extends AbstractController
     {
         $communityManager = $this->getCommunityManager($this->getWebspaceKey());
 
-        $response = $this->render($communityManager->getConfigTypeProperty(self::TYPE, Configuration::EMBED_TEMPLATE));
+        $maintenance = $communityManager->getConfigTypeProperty(Configuration::MAINTENANCE, Configuration::ENABLED);
+
+        $response = $this->render(
+            $communityManager->getConfigTypeProperty(self::TYPE, Configuration::EMBED_TEMPLATE),
+            [
+                'maintenanceMode' => $maintenance,
+            ]
+        );
 
         $response->setPrivate();
         $response->setMaxAge(0);

--- a/DependencyInjection/CompilerPass/CommunityManagerCompilerPass.php
+++ b/DependencyInjection/CompilerPass/CommunityManagerCompilerPass.php
@@ -55,6 +55,14 @@ class CommunityManagerCompilerPass implements CompilerPassInterface
                 $webspaceConfig[Configuration::EMAIL_TO] = null;
             }
 
+            if ($webspaceConfig[Configuration::MAINTENANCE][Configuration::ENABLED]) {
+                foreach (Configuration::$TYPES as $type) {
+                    if (isset($webspaceConfig[$type][Configuration::TEMPLATE])) {
+                        $webspaceConfig[$type][Configuration::TEMPLATE] = $webspaceConfig[Configuration::MAINTENANCE][Configuration::TEMPLATE];
+                    }
+                }
+            }
+
             $webspaceConfig[Configuration::WEBSPACE_KEY] = $webspaceKey;
             $webspacesConfig[$webspaceKey] = $webspaceConfig;
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -38,6 +38,7 @@ class Configuration implements ConfigurationInterface
     const ROLE = 'role';
     const WEBSPACE_KEY = 'webspace_key';
     const FIREWALL = 'firewall';
+    const MAINTENANCE = 'maintenance';
 
     // Form types
     const TYPE_LOGIN = 'login';
@@ -54,11 +55,20 @@ class Configuration implements ConfigurationInterface
 
     public static $TYPES = [
         self::TYPE_LOGIN,
-        self::TYPE_REGISTRATION,
+        self::TYPE_COMPLETION,
         self::TYPE_CONFIRMATION,
+        self::TYPE_REGISTRATION,
+        self::TYPE_PASSWORD_FORGET,
+        self::TYPE_PASSWORD_RESET,
+        self::TYPE_BLACKLISTED,
+        self::TYPE_BLACKLIST_CONFIRMED,
+        self::TYPE_BLACKLIST_DENIED,
+        self::TYPE_PROFILE,
+        self::TYPE_EMAIL_CONFIRMATION,
     ];
 
     // Type configurations
+    const ENABLED = 'enabled';
     const TEMPLATE = 'template';
     const SERVICE = 'service';
     const EMBED_TEMPLATE = 'embed_template';
@@ -129,6 +139,13 @@ class Configuration implements ConfigurationInterface
                             ->end()
                             ->scalarNode(self::ROLE)->defaultValue(null)->end()
                             ->scalarNode(self::FIREWALL)->defaultValue(null)->end()
+                            // Maintenance
+                            ->arrayNode(self::MAINTENANCE)
+                                ->canBeEnabled()
+                                ->children()
+                                    ->scalarNode(self::TEMPLATE)->defaultValue('SuluCommunityBundle:Maintenance:maintenance.html.twig')->end()
+                                ->end()
+                            ->end()
                             // Login
                             ->arrayNode(self::TYPE_LOGIN)
                                 ->addDefaultsIfNotSet()

--- a/Resources/doc/13-maintenance.md
+++ b/Resources/doc/13-maintenance.md
@@ -1,0 +1,33 @@
+# Maintenance
+
+You can temporarily change the community bundle into a maintenace mode 
+this will disable all form renderings.
+
+## Config
+
+```yml
+# app/config/config.yml
+
+sulu_community:
+    webspaces:
+        <webspace_key>:
+            maintenance:
+                enabled: false
+                template: AppBundle:template:community/Maintenance/maintenance.html.twig
+```
+
+The configured maintenance template will be rendered instead of configured 
+login, registration, completion, password forget, password reset, ... template.
+
+## Disable login embed
+
+In the `login-embed.html.twig` a variable `maintenanceMode` is available so you can render
+in the login embed another text instead.
+
+```twig
+{% if maintenanceMode %}
+    Maintenace mode active
+{% else %}
+    {# ... #}
+{% endif %}
+```

--- a/Resources/doc/3-customization.md
+++ b/Resources/doc/3-customization.md
@@ -19,7 +19,10 @@ sulu_community:
                 email: "%sulu_admin.email%"
             role: CustomRoleName
             firewall: CustomFirewallName
-
+            # Maintenance
+            maintenance:
+                enabled: false
+                template: AppBundle:template:community/Maintenance/maintenance.html.twig
             # Login
             login:
                 embed_template: AppBundle:templates:community/Login/login-embed.html.twig

--- a/Resources/views/Login/login-embed.html.twig
+++ b/Resources/views/Login/login-embed.html.twig
@@ -1,22 +1,26 @@
-{% if app.user %}
-    {% set media = null %}
-    {% if app.user.contact.avatar is not null %}
-        {% set media = sulu_resolve_media(app.user.contact.avatar, request.locale) %}
-    {% endif %}
-
-    <a href="{{ path('sulu_community.profile') }}">
-        {% if media is not null %}
-            <img src="{{ media.thumbnails['50x50'] }}"/>
+{{% if maintenanceMode %}
+    {# Show nothing in maintenance mode #}
+{% else %}
+    {% if app.user %}
+        {% set media = null %}
+        {% if app.user.contact.avatar is not null %}
+            {% set media = sulu_resolve_media(app.user.contact.avatar, request.locale) %}
         {% endif %}
 
-        {{ app.user.username|default('No username'|trans) }}
-    </a>
+        <a href="{{ path('sulu_community.profile') }}">
+            {% if media is not null %}
+                <img src="{{ media.thumbnails['50x50'] }}"/>
+            {% endif %}
 
-    <a href="{{ path('sulu_community.logout') }}">
-        {{ 'Logout'|trans }}
-    </a>
-{% else %}
-    <a href="{{ path('sulu_community.login') }}">
-        {{ 'Login'|trans }}
-    </a>
+            {{ app.user.username|default('No username'|trans) }}
+        </a>
+
+        <a href="{{ path('sulu_community.logout') }}">
+            {{ 'Logout'|trans }}
+        </a>
+    {% else %}
+        <a href="{{ path('sulu_community.login') }}">
+            {{ 'Login'|trans }}
+        </a>
+    {% endif %}
 {% endif %}

--- a/Resources/views/Maintenance/maintenance.html.twig
+++ b/Resources/views/Maintenance/maintenance.html.twig
@@ -1,0 +1,9 @@
+{% extends "SuluCommunityBundle::master.html.twig" %}
+
+{% block content %}
+    <h1>{{ 'Maintenance'|trans }}</h1>
+
+    <p>
+        {{ 'maintenance_message'|trans }}
+    </p>
+{% endblock %}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

It adds a maintenance flag and template to the community bundle which can be enabled and used instead of the other templates.

#### Why?

Sometimes you want temporarily disable community action e.g. Database migrations.

#### Example Usage

See documentation.

#### To Do

- [X] Create a documentation PR
