### PR TITLE
Fallback to email address to from email address when not set

### DIFF
--- a/DependencyInjection/CompilerPass/CommunityManagerCompilerPass.php
+++ b/DependencyInjection/CompilerPass/CommunityManagerCompilerPass.php
@@ -80,7 +80,7 @@ class CommunityManagerCompilerPass implements CompilerPassInterface
                 $webspaceConfig[Configuration::EMAIL_TO][Configuration::EMAIL_TO_EMAIL] => $webspaceConfig[Configuration::EMAIL_TO][Configuration::EMAIL_TO_NAME],
             ];
         } else {
-            $webspaceConfig[Configuration::EMAIL_TO] = null;
+            $webspaceConfig[Configuration::EMAIL_TO] = $webspaceConfig[Configuration::EMAIL_FROM];
         }
 
         // Set maintenance mode

--- a/Resources/doc/3-customization.md
+++ b/Resources/doc/3-customization.md
@@ -144,6 +144,7 @@ Type: `string`
 Example: test@test.com
 
 Will be used as receiver of the admin emails.
+If not configured it will fallback to from email address.
 
 #### role
 

--- a/Resources/doc/3-customization.md
+++ b/Resources/doc/3-customization.md
@@ -144,7 +144,7 @@ Type: `string`
 Example: test@test.com
 
 Will be used as receiver of the admin emails.
-If not configured it will fallback to from email address.
+If not configured it will fallback to the from configuration.
 
 #### role
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Fallback to email address to from email address.

#### Why?

To avoid errors as to is not required to be set.

#### Example Usage

~~~php
sulu_community:
    webspaces:
        <webspace_key>:
            from: "%from_email%"
~~~

