### PR TITLE
Allow webspaces with dash

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -104,6 +104,7 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
                 ->arrayNode('webspaces')
+                    ->normalizeKeys(false)
                     ->prototype('array')
                         ->children()
                             // Basic Webspace Configuration


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Symfony seems to normalize keys and replace `-` with `_`. https://symfony.com/doc/current/components/config/definition.html#normalization

#### Why?

Use normalizeKeys function (https://symfony.com/doc/current/components/config/definition.html) to disable this behaviour.

#### Example Usage

```php
sulu_community:
    webspace:
        test-intranet:
            from: test@example.org
```

