### PR TITLE
Use route name instead of path in security configuration

### DIFF
--- a/Resources/doc/2-setup-webspace.md
+++ b/Resources/doc/2-setup-webspace.md
@@ -57,10 +57,10 @@ security:
             pattern: ^/
             anonymous: ~
             form_login:
-                login_path: /login
-                check_path: /login
+                login_path: sulu_community.login
+                check_path: sulu_community.login
             logout:
-                path: /logout
+                path: sulu_community.logout
                 target: /
             remember_me:
                 secret:   "%secret%"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Use route name instead of path in security configuration

#### Why?

To avoid problems when have language specific urls for login

