### PR TITLE
Fix false firewall name and validate webspace in community admin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
 script:
   - ./vendor/bin/phpunit --coverage-clover=coverage.clover
   - ./Tests/app/console lint:twig Resources/views --env test
+  - ./Tests/app/console sulu:community:init -vvv --env test
   - if [[ $PHPSTAN == 'true' ]]; then ./vendor/bin/phpstan analyse ./ --level 2 -c phpstan.neon ; fi
 
 after_script:

--- a/Admin/CommunityAdmin.php
+++ b/Admin/CommunityAdmin.php
@@ -84,9 +84,35 @@ class CommunityAdmin extends Admin
     {
         $systems = [];
 
+        $webspaceCollection = $this->webspaceManager->getWebspaceCollection();
+
+        $webspaceKeys = array_keys($webspaceCollection->getWebspaces());
+
         foreach ($this->webspacesConfiguration as $webspaceKey => $webspaceConfig) {
-            $webspace = $this->webspaceManager->getWebspaceCollection()->getWebspace($webspaceKey);
-            $system = $webspace->getSecurity()->getSystem();
+            $webspace = $webspaceCollection->getWebspace($webspaceKey);
+
+            if (!$webspace) {
+                throw new \InvalidArgumentException(
+                    sprintf(
+                        'Webspace "%s" not found for "sulu_community" expected one of %s.',
+                        $webspaceKey,
+                        '"' . implode('", "', $webspaceKeys) . '"'
+                    )
+                );
+            }
+
+            $security = $webspace->getSecurity();
+
+            if (!$security) {
+                throw new \InvalidArgumentException(
+                    sprintf(
+                        'Missing "<security><system>Website</system><security>" configuration in webspace "%s" for "sulu_community".',
+                        $webspaceKey
+                    )
+                );
+            }
+
+            $system = $security->getSystem();
             $systems[$system] = [];
         }
 

--- a/Command/InitCommand.php
+++ b/Command/InitCommand.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\CommunityBundle\Command;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Bundle\CommunityBundle\DependencyInjection\CompilerPass\Normalizer;
 use Sulu\Bundle\CommunityBundle\DependencyInjection\Configuration;
 use Sulu\Bundle\CommunityBundle\Manager\CommunityManagerInterface;
 use Sulu\Bundle\SecurityBundle\Entity\Role;
@@ -78,7 +79,7 @@ class InitCommand extends ContainerAwareCommand
     {
         $webspaceKey = $webspace->getKey();
 
-        $communityServiceName = sprintf('sulu_community.%s.community_manager', $webspaceKey);
+        $communityServiceName = sprintf('sulu_community.%s.community_manager', Normalizer::normalize($webspaceKey));
 
         if (!$webspace->getSecurity() || !$this->getContainer()->has($communityServiceName)) {
             return;

--- a/Controller/AbstractController.php
+++ b/Controller/AbstractController.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\CommunityBundle\Controller;
 
+use Sulu\Bundle\CommunityBundle\DependencyInjection\CompilerPass\Normalizer;
 use Sulu\Bundle\CommunityBundle\DependencyInjection\Configuration;
 use Sulu\Bundle\CommunityBundle\Manager\CommunityManagerInterface;
 use Sulu\Bundle\SecurityBundle\Entity\User;
@@ -44,7 +45,7 @@ abstract class AbstractController extends Controller
     {
         if (!isset($this->communityManagers[$webspaceKey])) {
             $this->communityManagers[$webspaceKey] = $this->get(
-                sprintf('sulu_community.%s.community_manager', $webspaceKey)
+                sprintf('sulu_community.%s.community_manager', Normalizer::normalize($webspaceKey))
             );
         }
 

--- a/DependencyInjection/CompilerPass/CommunityManagerCompilerPass.php
+++ b/DependencyInjection/CompilerPass/CommunityManagerCompilerPass.php
@@ -37,9 +37,16 @@ class CommunityManagerCompilerPass implements CompilerPassInterface
             $definition->replaceArgument(1, $webspaceKey);
 
             $container->setDefinition(
-                sprintf('sulu_community.%s.community_manager', $webspaceKey),
+                sprintf('sulu_community.%s.community_manager', Normalizer::normalize($webspaceKey)),
                 $definition
             );
+
+            if (false !== strpos($webspaceKey, '-')) {
+                $container->setAlias(
+                    sprintf('sulu_community.%s.community_manager', $webspaceKey),
+                    sprintf('sulu_community.%s.community_manager', Normalizer::normalize($webspaceKey))
+                );
+            }
         }
 
         $container->setParameter('sulu_community.webspaces_config', $webspacesConfig);
@@ -61,7 +68,7 @@ class CommunityManagerCompilerPass implements CompilerPassInterface
         }
 
         // TODO currently symfony normalize the security firewalls key which will replace "-" with "_".
-        $webspaceConfig[Configuration::FIREWALL] = str_replace('-', '_', $webspaceConfig[Configuration::FIREWALL]);
+        $webspaceConfig[Configuration::FIREWALL] = Normalizer::normalize($webspaceConfig[Configuration::FIREWALL]);
 
         // Set role by webspace key
         if (null === $webspaceConfig[Configuration::ROLE]) {

--- a/DependencyInjection/CompilerPass/CommunityManagerCompilerPass.php
+++ b/DependencyInjection/CompilerPass/CommunityManagerCompilerPass.php
@@ -60,6 +60,9 @@ class CommunityManagerCompilerPass implements CompilerPassInterface
             $webspaceConfig[Configuration::FIREWALL] = $webspaceKey;
         }
 
+        // TODO currently symfony normalize the security firewalls key which will replace "-" with "_".
+        $webspaceConfig[Configuration::FIREWALL] = str_replace('-', '_', $webspaceConfig[Configuration::FIREWALL]);
+
         // Set role by webspace key
         if (null === $webspaceConfig[Configuration::ROLE]) {
             $webspaceConfig[Configuration::ROLE] = ucfirst($webspaceKey) . 'User';

--- a/DependencyInjection/CompilerPass/Normalizer.php
+++ b/DependencyInjection/CompilerPass/Normalizer.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CommunityBundle\DependencyInjection\CompilerPass;
+
+/**
+ * Only used for internal usages.
+ *
+ * @internal
+ */
+class Normalizer
+{
+    public static function normalize($text)
+    {
+        return str_replace('-', '_', $text);
+    }
+}

--- a/Resources/config/routing_website.xml
+++ b/Resources/config/routing_website.xml
@@ -36,10 +36,6 @@
         <default key="_controller">SuluCommunityBundle:Login:index</default>
     </route>
 
-    <route id="sulu_community.login" path="/login">
-        <default key="_controller">SuluCommunityBundle:Login:index</default>
-    </route>
-
     <route id="sulu_community.profile" path="/profile">
         <default key="_controller">SuluCommunityBundle:Profile:index</default>
     </route>

--- a/Tests/Functional/Controller/RegistrationTest.php
+++ b/Tests/Functional/Controller/RegistrationTest.php
@@ -38,7 +38,7 @@ class RegistrationTest extends SuluTestCase
 
         $role = new Role();
         $role->setName('Sulu-ioUser');
-        $role->setSystem('Sulu');
+        $role->setSystem('Website');
 
         $emailType = new EmailType();
         $emailType->setName('private');

--- a/Tests/Functional/Controller/RegistrationTest.php
+++ b/Tests/Functional/Controller/RegistrationTest.php
@@ -37,7 +37,7 @@ class RegistrationTest extends SuluTestCase
         $entityManager = $this->getEntityManager();
 
         $role = new Role();
-        $role->setName('Sulu_ioUser');
+        $role->setName('Sulu-ioUser');
         $role->setSystem('Sulu');
 
         $emailType = new EmailType();

--- a/Tests/Unit/Listener/BlacklistListenerTest.php
+++ b/Tests/Unit/Listener/BlacklistListenerTest.php
@@ -76,7 +76,7 @@ class BlacklistListenerTest extends \PHPUnit_Framework_TestCase
         $user->getEmail()->willReturn('test@sulu.io');
 
         $event = $this->prophesize(CommunityEvent::class);
-        $event->getConfigProperty(Configuration::WEBSPACE_KEY)->willReturn('sulu_io');
+        $event->getConfigProperty(Configuration::WEBSPACE_KEY)->willReturn('sulu-io');
         $event->getConfigProperty(Configuration::EMAIL_TO)->willReturn(['admin@sulu.io' => 'admin@sulu.io']);
         $event->getConfigProperty(Configuration::EMAIL_FROM)->willReturn(['from@sulu.io' => 'from@sulu.io']);
         $event->getConfigTypeProperty(Configuration::TYPE_BLACKLISTED, Configuration::EMAIL)->willReturn(
@@ -92,7 +92,7 @@ class BlacklistListenerTest extends \PHPUnit_Framework_TestCase
             Argument::that(
                 function (BlacklistUser $item) use ($user) {
                     return '123-123-123' === $item->getToken()
-                    && 'sulu_io' === $item->getWebspaceKey()
+                    && 'sulu-io' === $item->getWebspaceKey()
                     && $item->getUser() === $user->reveal();
                 }
             )

--- a/Tests/app/Resources/webspaces/sulu.io.xml
+++ b/Tests/app/Resources/webspaces/sulu.io.xml
@@ -4,7 +4,11 @@
            xsi:schemaLocation="http://schemas.sulu.io/webspace/webspace http://schemas.sulu.io/webspace/webspace-1.1.xsd">
 
     <name>Sulu CMF</name>
-    <key>sulu_io</key>
+    <key>sulu-io</key>
+
+    <security>
+        <system>Website</system>
+    </security>
 
     <localizations>
         <localization language="de" default="true"/>

--- a/Tests/app/config/config_admin.yml
+++ b/Tests/app/config/config_admin.yml
@@ -3,3 +3,8 @@ parameters:
 
 framework:
     router: { resource: "%kernel.root_dir%/config/routing_admin.yml" }
+
+sulu_community:
+    webspaces:
+        sulu-io:
+            from: 'admin@sulu.io'

--- a/Tests/app/config/config_website.yml
+++ b/Tests/app/config/config_website.yml
@@ -7,7 +7,7 @@ framework:
 
 sulu_community:
     webspaces:
-        sulu_io:
+        sulu-io:
             to: 'admin@sulu.io'
 
 sulu_security:

--- a/Tests/app/config/config_website.yml
+++ b/Tests/app/config/config_website.yml
@@ -8,7 +8,7 @@ framework:
 sulu_community:
     webspaces:
         sulu-io:
-            to: 'admin@sulu.io'
+            from: 'admin@sulu.io'
 
 sulu_security:
     checker:

--- a/Tests/app/config/config_website_prod.yml
+++ b/Tests/app/config/config_website_prod.yml
@@ -2,8 +2,7 @@ imports:
     - { resource: config_website.yml }
 
 security:
-    acl:
-        connection: default
+    session_fixation_strategy: none
 
     access_decision_manager:
         strategy: affirmative
@@ -16,14 +15,25 @@ security:
             id: sulu_security.user_provider
 
     access_control:
-       - { path: /login, roles: IS_AUTHENTICATED_ANONYMOUSLY }
        - { path: /profile, roles: ROLE_USER }
+       - { path: /completion, roles: ROLE_USER }
 
     firewalls:
-        test:
-            form_login:
-                login_path: /login
-                check_path: /login
-                default_target_path: sulu_community.profile
-            http_basic: ~
+        sulu-io:
+            pattern: ^/
             anonymous: ~
+            form_login:
+                login_path: sulu_community.login
+                check_path: sulu_community.login
+                default_target_path: sulu_community.profile
+            logout:
+                path: sulu_community.logout
+                target: /
+            remember_me:
+                secret:   "%secret%"
+                lifetime: 604800 # 1 week in seconds
+                path:     /
+
+sulu_security:
+    checker:
+        enabled: true


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #83
| License | MIT

#### What's in this PR?

Fix login embed and validate webspace in community admin.

#### Why?

Twig error on development for login embed. Validate if configured community webspace exist.


