### PR TITLE
Add missing documentation for asset install and generate translations

### DIFF
--- a/Resources/doc/1-installation.md
+++ b/Resources/doc/1-installation.md
@@ -29,7 +29,6 @@ public function registerBundles()
 To avoid the trying to register two bundles with the same name error remove
 the SecurityBundle from `app/AdminKernel.php`.
 
-
 ## Register Routes
 
 Register the website routes:
@@ -62,3 +61,19 @@ php bin/console doctrine:schema:update --dump-sql
 ``` 
 
 You can use `--force` to run the sqls but be carefully which other sql statements are executed.
+
+## Install assets
+
+Execute the following command to install the community bundle assets:
+
+```bash
+php bin/adminconsole assets:install --symlink --relative
+```
+
+## Generate translations
+
+Execute the following command to generate the new translations:
+
+```bash
+php bin/adminconsole sulu:translate:export
+```

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -5,6 +5,8 @@
 1. [Download and install](1-installation.md#download-and-install)
 2. [Enable Bundle](1-installation.md#enable-bundle)
 3. [Register Routes](1-installation.md#register-routes)
+4. [Install Assets](1-installation.md#install-assets)
+5. [Generate translations](1-installation.md#generate-translations)
 
 ## [Setup Webspace](2-setup-webspace.md)
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Add missing documentation for asset install and generate translations

#### Why?

For installation the assets:install and sulu:translate:export need to be called.
