### PR TITLE
Improve documentation with a better hint for duplicated bundle registration

### DIFF
--- a/Resources/doc/1-installation.md
+++ b/Resources/doc/1-installation.md
@@ -39,7 +39,7 @@ error. Remove the SecurityBundle from `app/AdminKernel.php`.
 public function registerBundles()
 {
      // ...
--    $bundles[] = new Symfony\Bundle\SecurityBundle\SecurityBundle(); // This following line need to be removed!
+-    $bundles[] = new Symfony\Bundle\SecurityBundle\SecurityBundle(); // This line need to be removed!
 ```
 
 ## Register Routes

--- a/Resources/doc/1-installation.md
+++ b/Resources/doc/1-installation.md
@@ -12,7 +12,7 @@ composer require sulu/community-bundle
 
 Enable the required bundles in the kernel:
 
-```bash
+```php
 <?php
 // app/AbstractKernel.php
 
@@ -26,8 +26,21 @@ public function registerBundles()
 }
 ```
 
-To avoid the trying to register two bundles with the same name error remove
-the SecurityBundle from `app/AdminKernel.php`.
+To avoid the:
+
+> Trying to register two bundles with the same name "SecurityBundle"
+
+error. Remove the SecurityBundle from `app/AdminKernel.php`.
+
+```diff
+<?php
+// app/AdminKernel.php
+
+public function registerBundles()
+{
+     // ...
+-    $bundles[] = new Symfony\Bundle\SecurityBundle\SecurityBundle(); // This following line need to be removed!
+```
 
 ## Register Routes
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Improve documentation with a better hint for duplicated bundle registration.

#### Why?

Code blocks are less ignored by developers when reading the documentation.