### PR TITLE
Fix compatibility with jms serializer 2, sulu 2 and mysql utf8mb4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,14 @@ cache:
 
 matrix:
   include:
-    - php: 5.5
+    - php: 7.1
       env:
-        - COMPOSER_FLAGS="--prefer-dist --no-interaction" # --prefer-lowest not possible in sulu 1.3
-    - php: 7.0
+        - COMPOSER_FLAGS="--prefer-dist --no-interaction --prefer-lowest"
+    - php: 7.2
       env:
         - COMPOSER_FLAGS="--prefer-dist --no-interaction"
         - CODE_COVERAGE=true
+        - PHPUNIT_FLAGS="--coverage-clover=coverage.clover"
         - PHPSTAN=true
 
 before_install:
@@ -28,7 +29,7 @@ install:
   - ./Tests/app/console doctrine:schema:update --force
 
 script:
-  - ./vendor/bin/phpunit --coverage-clover=coverage.clover
+  - ./vendor/bin/phpunit $PHPUNIT_FLAGS
   - ./Tests/app/console lint:twig Resources/views --env test
   - ./Tests/app/console sulu:community:init -vvv --env test
   - if [[ $PHPSTAN == 'true' ]]; then ./vendor/bin/phpstan analyse ./ --level 2 -c phpstan.neon ; fi

--- a/Controller/LoginController.php
+++ b/Controller/LoginController.php
@@ -12,7 +12,7 @@
 namespace Sulu\Bundle\CommunityBundle\Controller;
 
 use Sulu\Bundle\CommunityBundle\DependencyInjection\Configuration;
-use Sulu\Component\HttpCache\HttpCache;
+use Sulu\Bundle\HttpCacheBundle\Cache\AbstractHttpCache;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -71,7 +71,7 @@ class LoginController extends AbstractController
         $response->setSharedMaxAge(0);
         $response->headers->addCacheControlDirective('must-revalidate', true);
         $response->headers->addCacheControlDirective('no-store', true);
-        $response->headers->set(HttpCache::HEADER_REVERSE_PROXY_TTL, 0);
+        $response->headers->set(AbstractHttpCache::HEADER_REVERSE_PROXY_TTL, 0);
 
         return $response;
     }

--- a/DependencyInjection/SuluCommunityExtension.php
+++ b/DependencyInjection/SuluCommunityExtension.php
@@ -102,6 +102,7 @@ class SuluCommunityExtension extends Extension implements PrependExtensionInterf
                     'metadata' => [
                         'directories' => [
                             [
+                                'name' => 'sulu_community',
                                 'path' => __DIR__ . '/../Resources/config/serializer',
                                 'namespace_prefix' => 'Sulu\Bundle\CommunityBundle\Entity',
                             ],

--- a/Resources/config/doctrine/BlacklistItem.orm.xml
+++ b/Resources/config/doctrine/BlacklistItem.orm.xml
@@ -12,9 +12,8 @@
             <generator strategy="AUTO"/>
         </id>
 
-        <field name="pattern" type="string" column="pattern" unique="true"/>
-        <field name="regexp" type="string" column="regexpPattern"/>
+        <field name="pattern" type="string" length="191" column="pattern" unique="true"/>
+        <field name="regexp" type="string" length="191" column="regexpPattern"/>
         <field name="type" type="string" column="type"/>
-
     </entity>
 </doctrine-mapping>

--- a/Resources/config/doctrine/BlacklistUser.orm.xml
+++ b/Resources/config/doctrine/BlacklistUser.orm.xml
@@ -12,7 +12,7 @@
             <generator strategy="AUTO"/>
         </id>
 
-        <field name="token" type="string" column="token" unique="true" nullable="true"/>
+        <field name="token" type="string" column="token" length="191" unique="true" nullable="true"/>
         <field name="type" type="integer" column="type"/>
         <field name="webspaceKey" type="string" column="webspaceKey"/>
 

--- a/Resources/config/doctrine/EmailConfirmationToken.orm.xml
+++ b/Resources/config/doctrine/EmailConfirmationToken.orm.xml
@@ -12,7 +12,7 @@
             <generator strategy="AUTO"/>
         </id>
 
-        <field name="token" type="string" column="token" unique="true"/>
+        <field name="token" type="string" length="191" column="token" unique="true"/>
 
         <one-to-one field="user" target-entity="Sulu\Component\Security\Authentication\UserInterface">
             <join-column name="userId" referenced-column-name="id" on-delete="CASCADE"/>

--- a/Tests/app/config/config_admin.yml
+++ b/Tests/app/config/config_admin.yml
@@ -8,3 +8,13 @@ sulu_community:
     webspaces:
         sulu-io:
             from: 'admin@sulu.io'
+
+doctrine:
+    orm:
+        mappings:
+            gedmo_tree:
+                type: xml
+                prefix: Gedmo\Tree\Entity
+                dir: "%kernel.root_dir%/../../vendor/gedmo/doctrine-extensions/lib/Gedmo/Tree/Entity"
+                alias: GedmoTree
+                is_bundle: false

--- a/Tests/app/config/config_website.yml
+++ b/Tests/app/config/config_website.yml
@@ -16,3 +16,13 @@ sulu_security:
 
 swiftmailer:
     disable_delivery:  true
+
+doctrine:
+    orm:
+        mappings:
+            gedmo_tree:
+                type: xml
+                prefix: Gedmo\Tree\Entity
+                dir: "%kernel.root_dir%/../../vendor/gedmo/doctrine-extensions/lib/Gedmo/Tree/Entity"
+                alias: GedmoTree
+                is_bundle: false

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,19 @@
 # Upgrade
 
+## 2.0.0 (unreleased)
+
+### UTF8MB4 compatibility
+
+To support utf8mb4 we needed to shorten the length of indexed fields
+Run the following SQLs to upgrade your DB:
+
+```sql
+ALTER TABLE com_email_token CHANGE token token VARCHAR(191) NOT NULL;
+ALTER TABLE com_blacklist_user CHANGE token token VARCHAR(191) DEFAULT NULL;
+ALTER TABLE com_blacklist_item CHANGE regexpPattern regexpPattern VARCHAR(191) NOT NULL;
+ALTER TABLE com_blacklist_item CHANGE pattern pattern VARCHAR(191) NOT NULL;
+```
+
 ## 0.3.0
 
 ### Parameter `sulu_community.config` was removed

--- a/composer.json
+++ b/composer.json
@@ -4,17 +4,18 @@
     "type": "sulu-bundle",
     "license": "MIT",
     "require": {
-        "php": "^5.5 || ^7.0",
-        "symfony/symfony": "^2.8.7 || ^3.0",
+        "php": "^7.1",
+        "symfony/symfony": "^3.4",
         "symfony/security-acl": "~2.7|~3.0.0",
-        "sulu/sulu": "^1.3",
+        "sulu/sulu": "dev-develop",
+        "jms/serializer-bundle": "^2.0",
         "massive/build-bundle": "^0.2 || ^0.3",
         "symfony/swiftmailer-bundle": "~2.3",
         "beberlei/DoctrineExtensions": "^1.0"
     },
     "require-dev": {
         "jackalope/jackalope-doctrine-dbal": "^1.2.5",
-        "symfony/monolog-bundle": "^2.8.7 || ^3.0",
+        "symfony/monolog-bundle": "^3.1",
         "massive/search-bundle": "@dev",
         "zendframework/zend-stdlib": "~2.3",
         "zendframework/zendsearch": "@dev",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Fix compatibility with jms serializer.

#### Why?

Following error does appear on sulu 2.0:

> The attribute "name" must be set for path "jms_serializer.metadata.directories"

