### PR TITLE
WIP: Added social-media user-provider

### DIFF
--- a/Controller/RegistrationController.php
+++ b/Controller/RegistrationController.php
@@ -12,7 +12,6 @@
 namespace Sulu\Bundle\CommunityBundle\Controller;
 
 use Sulu\Bundle\CommunityBundle\DependencyInjection\Configuration;
-use Sulu\Bundle\SecurityBundle\Entity\User;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/DependencyInjection/SuluCommunityExtension.php
+++ b/DependencyInjection/SuluCommunityExtension.php
@@ -40,6 +40,11 @@ class SuluCommunityExtension extends Extension implements PrependExtensionInterf
         $loader->load('services.xml');
         $loader->load('validator.xml');
 
+        $bundles = $container->getParameter('kernel.bundles');
+        if (array_key_exists('HttplugBundle', $bundles) && array_key_exists('HWIOAuthBundle', $bundles)) {
+            $loader->load('social-media-login.xml');
+        }
+
         if ($lastLoginEnabled) {
             $lastLoginRefreshInterval = $config[Configuration::LAST_LOGIN][Configuration::REFRESH_INTERVAL];
 

--- a/Entity/UserAccessToken.php
+++ b/Entity/UserAccessToken.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CommunityBundle\Entity;
+
+use Sulu\Component\Security\Authentication\UserInterface;
+
+class UserAccessToken
+{
+    /**
+     * @var UserInterface
+     */
+    private $user;
+
+    /**
+     * @var string
+     */
+    private $service;
+
+    /**
+     * @var string
+     */
+    private $identifier;
+
+    /**
+     * @var string
+     */
+    private $accessToken;
+
+    public function __construct(UserInterface $user, string $service, string $identifier)
+    {
+        $this->user = $user;
+        $this->service = $service;
+        $this->identifier = $identifier;
+    }
+
+    public function getUser(): UserInterface
+    {
+        return $this->user;
+    }
+
+    public function getService(): string
+    {
+        return $this->service;
+    }
+
+    public function getIdentifier(): string
+    {
+        return $this->identifier;
+    }
+
+    public function getAccessToken(): string
+    {
+        return $this->accessToken;
+    }
+
+    public function setAccessToken(string $accessToken): self
+    {
+        $this->accessToken = $accessToken;
+
+        return $this;
+    }
+}

--- a/Entity/UserAccessToken.php
+++ b/Entity/UserAccessToken.php
@@ -33,7 +33,7 @@ class UserAccessToken
     /**
      * @var string
      */
-    private $accessToken;
+    private $accessToken = '';
 
     public function __construct(UserInterface $user, string $service, string $identifier)
     {

--- a/Entity/UserAccessTokenRepository.php
+++ b/Entity/UserAccessTokenRepository.php
@@ -19,8 +19,10 @@ class UserAccessTokenRepository extends EntityRepository
     public function create(UserInterface $user, string $service, string $identifier): UserAccessToken
     {
         $class = $this->getClassName();
+        $accessToken = new $class($user, $service, $identifier);
+        $this->getEntityManager()->persist($accessToken);
 
-        return new $class($user, $service, $identifier);
+        return $accessToken;
     }
 
     public function findByIdentifier(string $service, string $identifier): ?UserAccessToken

--- a/Entity/UserAccessTokenRepository.php
+++ b/Entity/UserAccessTokenRepository.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CommunityBundle\Entity;
+
+use Doctrine\ORM\EntityRepository;
+use Sulu\Component\Security\Authentication\UserInterface;
+
+class UserAccessTokenRepository extends EntityRepository
+{
+    public function create(UserInterface $user, string $service, string $identifier): UserAccessToken
+    {
+        $class = $this->getClassName();
+
+        return new $class($user, $service, $identifier);
+    }
+
+    public function findByIdentifier(string $service, string $identifier): ?UserAccessToken
+    {
+        return $this->findOneBy(['service' => $service, 'identifier' => $identifier]);
+    }
+}

--- a/Resources/config/doctrine/UserAccessToken.orm.xml
+++ b/Resources/config/doctrine/UserAccessToken.orm.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+    <entity name="Sulu\Bundle\CommunityBundle\Entity\UserAccessToken" table="com_user_access_tokens"
+            repository-class="Sulu\Bundle\CommunityBundle\Entity\UserAccessTokenRepository">
+        <indexes>
+            <index columns="identifier"/>
+        </indexes>
+
+        <unique-constraints>
+            <unique-constraint columns="service,identifier"/>
+        </unique-constraints>
+
+        <id name="user" type="integer" association-key="true">
+            <generator strategy="NONE"/>
+        </id>
+
+        <id name="service" type="string" length="32">
+            <generator strategy="NONE"/>
+        </id>
+
+        <field name="identifier" type="string" nullable="false" length="128"/>
+        <field name="accessToken" type="string" nullable="false"/>
+
+        <many-to-one field="user" target-entity="Sulu\Component\Security\Authentication\UserInterface">
+            <join-column name="userId" referenced-column-name="id" on-delete="CASCADE"/>
+        </many-to-one>
+    </entity>
+</doctrine-mapping>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -140,5 +140,10 @@
             <argument type="service" id="templating"/>
             <argument type="service" id="translator"/>
         </service>
+
+        <!-- social-media -->
+        <service id="sulu_community.social_media.oauth_provider" class="Sulu\Bundle\CommunityBundle\SocialMedia\SocialMediaUserProvider">
+            <argument type="service" id="doctrine"/>
+        </service>
     </services>
 </container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -25,6 +25,8 @@
             <argument type="service" id="security.token_storage"/>
             <argument type="service" id="sulu_community.user_manager"/>
             <argument type="service" id="sulu_community.mail_factory"/>
+            <argument type="service" id="request_stack"/>
+            <argument>%kernel.default_locale%</argument>
         </service>
 
         <!-- User Manager -->

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -150,6 +150,8 @@
 
         <!-- social-media -->
         <service id="sulu_community.social_media.oauth_provider" class="Sulu\Bundle\CommunityBundle\SocialMedia\SocialMediaUserProvider">
+            <argument type="service" id="sulu_community.community_manager.registry"/>
+            <argument type="service" id="request_stack"/>
             <argument type="service" id="doctrine"/>
         </service>
     </services>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -147,12 +147,5 @@
             <argument type="service" id="templating"/>
             <argument type="service" id="translator"/>
         </service>
-
-        <!-- social-media -->
-        <service id="sulu_community.social_media.oauth_provider" class="Sulu\Bundle\CommunityBundle\SocialMedia\SocialMediaUserProvider">
-            <argument type="service" id="sulu_community.community_manager.registry"/>
-            <argument type="service" id="request_stack"/>
-            <argument type="service" id="doctrine"/>
-        </service>
     </services>
 </container>

--- a/Resources/config/social-media-login.xml
+++ b/Resources/config/social-media-login.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="sulu_community.social_media.oauth_provider" class="Sulu\Bundle\CommunityBundle\SocialMedia\SocialMediaUserProvider">
+            <argument type="service" id="sulu_community.community_manager.registry"/>
+            <argument type="service" id="request_stack"/>
+            <argument type="service" id="doctrine"/>
+        </service>
+    </services>
+</container>

--- a/SocialMedia/SocialMediaUserProvider.php
+++ b/SocialMedia/SocialMediaUserProvider.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CommunityBundle\SocialMedia;
+
+use Doctrine\Common\Persistence\ManagerRegistry;
+use HWI\Bundle\OAuthBundle\Connect\AccountConnectorInterface;
+use HWI\Bundle\OAuthBundle\OAuth\Response\UserResponseInterface;
+use HWI\Bundle\OAuthBundle\Security\Core\User\EntityUserProvider as BaseClass;
+use Sulu\Bundle\CommunityBundle\Entity\UserAccessToken;
+use Sulu\Bundle\CommunityBundle\Entity\UserAccessTokenRepository;
+use Sulu\Bundle\ContactBundle\Entity\ContactInterface;
+use Sulu\Bundle\ContactBundle\Entity\ContactRepositoryInterface;
+use Sulu\Component\Security\Authentication\UserInterface as SuluUserInterface;
+use Sulu\Component\Security\Authentication\UserRepositoryInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class SocialMediaUserProvider extends BaseClass implements AccountConnectorInterface
+{
+    /**
+     * @var UserAccessTokenRepository
+     */
+    private $userAccessTokenRepository;
+
+    /**
+     * @var UserRepositoryInterface
+     */
+    private $userRepository;
+
+    /**
+     * @var ContactRepositoryInterface
+     */
+    private $contactRepository;
+
+    public function __construct(
+        ManagerRegistry $registry,
+        $class = SuluUserInterface::class,
+        array $properties = [],
+        $managerName = null
+    ) {
+        parent::__construct($registry, $class, $properties, $managerName);
+
+        $this->userAccessTokenRepository = $this->em->getRepository(UserAccessToken::class);
+        $this->userRepository = $this->em->getRepository($this->em->getClassMetadata(SuluUserInterface::class)->getName());
+        $this->contactRepository = $this->em->getRepository($this->em->getClassMetadata(ContactInterface::class)->getName());
+    }
+
+    public function connect(UserInterface $user, UserResponseInterface $response)
+    {
+        // On connect, retrieve the access token and the user id
+        $service = $response->getResourceOwner()->getName();
+        $username = $response->getUsername();
+
+        // Disconnect previously connected users
+        $previousAccessToken = $this->userAccessTokenRepository->findByIdentifier($service, $username);
+        if ($previousAccessToken) {
+            $this->em->remove($previousAccessToken);
+
+            // FIXME necessary?
+            $this->em->flush();
+        }
+
+        $accessToken = $this->userAccessTokenRepository->create($user, $service, $username);
+        $accessToken->setAccessToken($response->getAccessToken());
+
+        // FIXME necessary?
+        $this->em->flush();
+    }
+
+    public function loadUserByOAuthUserResponse(UserResponseInterface $response)
+    {
+        $service = $response->getResourceOwner()->getName();
+        $username = $response->getUsername();
+        $email = $response->getEmail() ? $response->getEmail() : $username;
+
+        $accessToken = $this->userAccessTokenRepository->findByIdentifier($service, $username);
+
+        // If the user exists
+        if ($accessToken) {
+            // set access-token and return
+            $accessToken->setAccessToken($response->getAccessToken());
+
+            $user = $accessToken->getUser();
+            $user->setEmail($email);
+
+            $contact = $user->getContact();
+            $contact->setFirstName($response->getFirstName());
+            $contact->setLastName($response->getLastName());
+
+            // FIXME necessary?
+            $this->em->flush();
+
+            return $accessToken->getUser();
+        }
+
+        // else create new user
+        $user = $this->userRepository->createNew();
+
+        $accessToken = $this->userAccessTokenRepository->create($user, $service, $username);
+        $accessToken->setAccessToken($response->getAccessToken());
+
+        $contact = $this->contactRepository->createNew();
+        $contact->setFirstName($response->getFirstName());
+        $contact->setLastName($response->getLastName());
+        $user->setContact($contact);
+
+        $user->setUsername($this->generateRandomUsername($username, $service));
+        $user->setEmail($email);
+        $user->setSalt(uniqid());
+        $user->setPassword($username);
+        $user->setEnabled(true);
+        $user->setLocale('de'); // FIXME locale
+
+        $this->em->persist($contact);
+        $this->em->persist($user);
+        $this->em->persist($accessToken);
+
+        // FIXME necessary?
+        $this->em->flush();
+
+        return $user;
+    }
+
+    private function generateRandomUsername($username, $serviceName)
+    {
+        if (!$username) {
+            $username = 'user' . uniqid((rand()), true) . $serviceName;
+        }
+
+        return $username . '_' . $serviceName;
+    }
+}

--- a/Tests/Unit/Controller/SaveMediaTraitTest.php
+++ b/Tests/Unit/Controller/SaveMediaTraitTest.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\CommunityBundle\Tests\Unit\Controller;
 
+use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\CommunityBundle\Controller\SaveMediaTrait;
 use Sulu\Bundle\ContactBundle\Entity\Contact;
 use Sulu\Bundle\MediaBundle\Api\Media as ApiMedia;
@@ -21,7 +22,7 @@ use Sulu\Component\Media\SystemCollections\SystemCollectionManagerInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
-class SaveMediaTraitTest extends \PHPUnit_Framework_TestCase
+class SaveMediaTraitTest extends TestCase
 {
     use SaveMediaTrait {
         getMediaManager as mockedGetMediaManager;

--- a/Tests/Unit/Entity/UserAccessTokenTest.php
+++ b/Tests/Unit/Entity/UserAccessTokenTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Tests\Unit\Entity;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\CommunityBundle\Entity\UserAccessToken;
+use Sulu\Component\Security\Authentication\UserInterface;
+
+class UserAccessTokenTest extends TestCase
+{
+    public function testGetUser()
+    {
+        $user = $this->prophesize(UserInterface::class);
+        $entity = new UserAccessToken($user->reveal(), 'facebook', '123-123-123');
+
+        $this->assertEquals($user->reveal(), $entity->getUser());
+    }
+
+    public function testGetService()
+    {
+        $user = $this->prophesize(UserInterface::class);
+        $entity = new UserAccessToken($user->reveal(), 'facebook', '123-123-123');
+
+        $this->assertEquals('facebook', $entity->getService());
+    }
+
+    public function testGetIdentifier()
+    {
+        $user = $this->prophesize(UserInterface::class);
+        $entity = new UserAccessToken($user->reveal(), 'facebook', '123-123-123');
+
+        $this->assertEquals('123-123-123', $entity->getService());
+    }
+
+    public function testGetAccessToken()
+    {
+        $user = $this->prophesize(UserInterface::class);
+        $entity = new UserAccessToken($user->reveal(), 'facebook', '123-123-123');
+
+        $this->assertEquals('', $entity->getAccessToken());
+    }
+
+    public function testSetAccessToken()
+    {
+        $user = $this->prophesize(UserInterface::class);
+        $entity = new UserAccessToken($user->reveal(), 'facebook', '123-123-123');
+
+        $this->assertEquals($entity, $entity->setAccessToken('my-token'));
+        $this->assertEquals('my-token', $entity->getAccessToken());
+    }
+}

--- a/Tests/Unit/Manager/CommunityManagerRegistryTest.php
+++ b/Tests/Unit/Manager/CommunityManagerRegistryTest.php
@@ -11,10 +11,11 @@
 
 namespace Sulu\Bundle\CommunityBundle\Tests\Unit\Manager;
 
+use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\CommunityBundle\Manager\CommunityManager;
 use Sulu\Bundle\CommunityBundle\Manager\CommunityManagerRegistry;
 
-class CommunityManagerRegistryTest extends \PHPUnit_Framework_TestCase
+class CommunityManagerRegistryTest extends TestCase
 {
     public function testGet()
     {

--- a/Tests/Unit/SocialMedia/SocialMediaUserProviderTest.php
+++ b/Tests/Unit/SocialMedia/SocialMediaUserProviderTest.php
@@ -1,0 +1,245 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Tests\Unit\SocialMedia;
+
+use Doctrine\Bundle\DoctrineBundle\Registry;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
+use HWI\Bundle\OAuthBundle\OAuth\Response\UserResponseInterface;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Sulu\Bundle\CommunityBundle\Entity\UserAccessToken;
+use Sulu\Bundle\CommunityBundle\Entity\UserAccessTokenRepository;
+use Sulu\Bundle\CommunityBundle\Manager\CommunityManagerInterface;
+use Sulu\Bundle\CommunityBundle\Manager\CommunityManagerRegistryInterface;
+use Sulu\Bundle\CommunityBundle\SocialMedia\SocialMediaUserProvider;
+use Sulu\Bundle\ContactBundle\Entity\Contact;
+use Sulu\Bundle\ContactBundle\Entity\ContactInterface;
+use Sulu\Bundle\ContactBundle\Entity\ContactRepositoryInterface;
+use Sulu\Bundle\SecurityBundle\Entity\User;
+use Sulu\Component\Security\Authentication\UserInterface;
+use Sulu\Component\Security\Authentication\UserRepositoryInterface;
+use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
+use Sulu\Component\Webspace\Webspace;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class SocialMediaUserProviderTest extends TestCase
+{
+    /**
+     * @var CommunityManagerRegistryInterface
+     */
+    private $communityManagerRegistry;
+
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @var Registry
+     */
+    private $registry;
+
+    /**
+     * @var EntityManagerInterface
+     */
+    private $entityManager;
+
+    /**
+     * @var UserRepositoryInterface
+     */
+    private $userRepository;
+
+    /**
+     * @var ContactRepositoryInterface
+     */
+    private $contactRepository;
+
+    /**
+     * @var UserAccessTokenRepository
+     */
+    private $userAccessTokenRepository;
+
+    protected function setUp()
+    {
+        $this->communityManagerRegistry = $this->prophesize(CommunityManagerRegistryInterface::class);
+        $this->requestStack = $this->prophesize(RequestStack::class);
+        $this->registry = $this->prophesize(Registry::class);
+
+        $this->entityManager = $this->prophesize(EntityManagerInterface::class);
+        $userMetadata = $this->prophesize(ClassMetadata::class);
+        $userMetadata->getName()->willReturn(User::class);
+        $contactMetadata = $this->prophesize(ClassMetadata::class);
+        $contactMetadata->getName()->willReturn(Contact::class);
+        $this->entityManager->getClassMetadata(UserInterface::class)->willReturn($userMetadata->reveal());
+        $this->entityManager->getClassMetadata(ContactInterface::class)->willReturn($contactMetadata->reveal());
+
+        $this->userRepository = $this->prophesize(UserRepositoryInterface::class);
+        $this->contactRepository = $this->prophesize(ContactRepositoryInterface::class);
+        $this->userAccessTokenRepository = $this->prophesize(UserAccessTokenRepository::class);
+
+        $this->entityManager->getRepository(User::class)->willReturn($this->userRepository->reveal());
+        $this->entityManager->getRepository(Contact::class)->willReturn($this->contactRepository->reveal());
+        $this->entityManager->getRepository(UserAccessToken::class)->willReturn($this->userAccessTokenRepository->reveal());
+    }
+
+    public function testConnect()
+    {
+        $provider = new SocialMediaUserProvider(
+            $this->communityManagerRegistry->reveal(),
+            $this->requestStack->reveal(),
+            $this->registry->reveal()
+        );
+
+        $user = $this->prophesize(UserInterface::class);
+        $response = $this->prophesize(UserResponseInterface::class);
+        $resourceOwner = $this->prophesize(ResourceOwnerInterface::class);
+        $resourceOwner->getName()->willReturn('facebook');
+        $response->getResourceOwner()->willReturn($resourceOwner->reveal());
+        $response->getUsername()->willReturn('test');
+        $response->getAccessToken()->willReturn('123-123-123');
+
+        $this->userAccessTokenRepository->findByIdentifier('facebook', 'test')->willReturn(null);
+
+        $accessToken = $this->prophesize(UserAccessToken::class);
+        $accessToken->setAccessToken('123-123-123')->willReturn($accessToken)->shouldBeCalled();
+
+        $this->entityManager->flush()->shouldBeCalled();
+
+        $provider->connect($user->reveal(), $response->reveal());
+    }
+
+    public function testConnectRemoveExisting()
+    {
+        $provider = new SocialMediaUserProvider(
+            $this->communityManagerRegistry->reveal(),
+            $this->requestStack->reveal(),
+            $this->registry->reveal()
+        );
+
+        $user = $this->prophesize(UserInterface::class);
+        $response = $this->prophesize(UserResponseInterface::class);
+        $resourceOwner = $this->prophesize(ResourceOwnerInterface::class);
+        $resourceOwner->getName()->willReturn('facebook');
+        $response->getResourceOwner()->willReturn($resourceOwner->reveal());
+        $response->getUsername()->willReturn('test');
+        $response->getAccessToken()->willReturn('123-123-123');
+
+        $oldUserAccessToken = $this->prophesize(UserAccessToken::class);
+        $this->userAccessTokenRepository->findByIdentifier('facebook', 'test')
+            ->willReturn($oldUserAccessToken->reveal());
+
+        $this->entityManager->remove($oldUserAccessToken->reveal());
+        $this->entityManager->flush()->shouldBeCalled();
+
+        $accessToken = $this->prophesize(UserAccessToken::class);
+        $accessToken->setAccessToken('123-123-123')->willReturn($accessToken->reveal())->shouldBeCalled();
+
+        $provider->connect($user->reveal(), $response->reveal());
+    }
+
+    public function testLoadUserByOAuthUserResponseExistingUser()
+    {
+        $provider = new SocialMediaUserProvider(
+            $this->communityManagerRegistry->reveal(),
+            $this->requestStack->reveal(),
+            $this->registry->reveal()
+        );
+
+        $response = $this->prophesize(UserResponseInterface::class);
+        $resourceOwner = $this->prophesize(ResourceOwnerInterface::class);
+        $resourceOwner->getName()->willReturn('facebook');
+        $response->getResourceOwner()->willReturn($resourceOwner->reveal());
+        $response->getUsername()->willReturn('test');
+        $response->getFirstName()->willReturn('Max');
+        $response->getLastName()->willReturn('Mustermann');
+        $response->getEmail()->willReturn(null);
+        $response->getAccessToken()->willReturn('123-123-123');
+
+        $accessToken = $this->prophesize(UserAccessToken::class);
+        $this->userAccessTokenRepository->findByIdentifier('facebook', 'test')
+            ->willReturn($accessToken->reveal());
+        $accessToken->setAccessToken('123-123-123')->willReturn($accessToken->reveal())->shouldBeCalled();
+
+        $user = $this->prophesize(User::class);
+        $contact = $this->prophesize(ContactInterface::class);
+        $user->getContact()->willReturn($contact->reveal());
+
+        $contact->setFirstName('Max')->shouldBeCalled();
+        $contact->setLastName('Mustermann')->shouldBeCalled();
+
+        $this->entityManager->flush()->shouldBeCalled();
+
+        $accessToken->getUser()->willReturn($user->reveal());
+
+        $result = $provider->loadUserByOAuthUserResponse($response->reveal());
+        $this->assertEquals($user->reveal(), $result);
+    }
+
+    public function testLoadUserByOAuthUserResponse()
+    {
+        $provider = new SocialMediaUserProvider(
+            $this->communityManagerRegistry->reveal(),
+            $this->requestStack->reveal(),
+            $this->registry->reveal()
+        );
+
+        $response = $this->prophesize(UserResponseInterface::class);
+        $resourceOwner = $this->prophesize(ResourceOwnerInterface::class);
+        $resourceOwner->getName()->willReturn('facebook');
+        $response->getResourceOwner()->willReturn($resourceOwner->reveal());
+        $response->getUsername()->willReturn('test');
+        $response->getFirstName()->willReturn('Max');
+        $response->getLastName()->willReturn('Mustermann');
+        $response->getEmail()->willReturn('max@mustermann.at');
+        $response->getAccessToken()->willReturn('123-123-123');
+
+        $this->userAccessTokenRepository->findByIdentifier('facebook', 'test')->willReturn(null);
+
+        $accessToken = $this->prophesize(UserAccessToken::class);
+        $accessToken->setAccessToken('123-123-123')->willReturn($accessToken->reveal())->shouldBeCalled();
+
+        $user = $this->prophesize(User::class);
+        $this->userRepository->createNew()->willReturn($user->reveal());
+
+        $contact = $this->prophesize(ContactInterface::class);
+        $this->contactRepository->createNew()->willReturn($contact->reveal());
+        $contact->setFirstName('Max')->shouldBeCalled();
+        $contact->setLastName('Mustermann')->shouldBeCalled();
+
+        $user->setContact($contact->reveal())->shouldBeCalled();
+        $user->setUsername(Argument::type('string'))->shouldBeCalled();
+        $user->setEmail('max@mustermann.at')->shouldBeCalled();
+        $user->setSalt(Argument::type('string'))->shouldBeCalled();
+        $user->setPassword(Argument::type('string'))->shouldBeCalled();
+
+        $request = new Request();
+        $requestAttributes = $this->prophesize(RequestAttributes::class);
+        $request->attributes->set('_sulu', $requestAttributes->reveal());
+
+        $webspace = $this->prophesize(Webspace::class);
+        $webspace->getKey()->willReturn('sulu_io');
+        $requestAttributes->getAttribute('webspace')->willReturn($webspace->reveal());
+
+        $communityManager = $this->prophesize(CommunityManagerInterface::class);
+        $communityManager->register($user->reveal())->shouldBeCalled();
+        $this->communityManagerRegistry->get('sulu_io')->willReturn($communityManager->reveal());
+        $user->setEnabled(true)->shouldBeCalled();
+
+        $this->entityManager->flush()->shouldBeCalled();
+
+        $result = $provider->loadUserByOAuthUserResponse($response->reveal());
+        $this->assertEquals($user->reveal(), $result);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,9 @@
         "symfony/routing": "^3.4",
         "symfony/security": "^3.4",
         "symfony/security-acl": "^2.8 || ^3.0",
-        "symfony/swiftmailer-bundle": "^2.6.4"
+        "symfony/swiftmailer-bundle": "^2.6.4",
+        "hwi/oauth-bundle": "^0.6.2",
+        "php-http/httplug-bundle": "^1.10"
     },
     "require-dev": {
         "jackalope/jackalope-doctrine-dbal": "^1.2.5",

--- a/composer.json
+++ b/composer.json
@@ -23,13 +23,13 @@
         "symfony/routing": "^3.4",
         "symfony/security": "^3.4",
         "symfony/security-acl": "^2.8 || ^3.0",
-        "symfony/swiftmailer-bundle": "^2.6.4",
-        "hwi/oauth-bundle": "^0.6.2",
-        "php-http/httplug-bundle": "^1.10"
+        "symfony/swiftmailer-bundle": "^2.6.4"
     },
     "require-dev": {
+        "hwi/oauth-bundle": "^0.6.2",
         "jackalope/jackalope-doctrine-dbal": "^1.2.5",
         "massive/search-bundle": "@dev",
+        "php-http/httplug-bundle": "^1.10",
         "phpstan/phpstan": "^0.10.0",
         "phpunit/phpunit": "^6.5",
         "symfony/browser-kit": "^3.4",
@@ -38,6 +38,10 @@
         "symfony/stopwatch": "^3.4",
         "zendframework/zend-stdlib": "~2.3",
         "zendframework/zendsearch": "@dev"
+    },
+    "suggest": {
+        "hwi/oauth-bundle": "Allows register/login with social-media accounts",
+        "php-http/httplug-bundle": "Dependency of hwi/oauth-bundle"
     },
     "keywords": [
         "registration",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

This PR integrates the `HWIOAuthBundle` to allow social-media logins via facebook, google and co.

#### To Do

- [ ] Tests
- [x] Cleanup code
- [ ] Add Documentation
- [x] Make this feature optional
- [ ] Fix confirmation Url generation when registered routes correctly as type portal routes (reported in [slack](https://sulu-io.slack.com/archives/C0430GGCV/p1550589172154900?thread_ts=1550586143.150000&cid=C0430GGCV))
- [ ] Rebase for 1.x