### PR TITLE
Added contact documents upload and fixed profile without avatar

### DIFF
--- a/Controller/CompletionController.php
+++ b/Controller/CompletionController.php
@@ -21,6 +21,8 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
  */
 class CompletionController extends AbstractController
 {
+    use SaveMediaTrait;
+
     const TYPE = Configuration::TYPE_COMPLETION;
 
     /**
@@ -53,6 +55,8 @@ class CompletionController extends AbstractController
         // Handle Form Success
         if ($form->isSubmitted() && $form->isValid()) {
             $user = $form->getData();
+
+            $this->saveMediaFields($form, $user, $request->getLocale());
 
             // Completion User
             $communityManager->completion($user);

--- a/Controller/ProfileController.php
+++ b/Controller/ProfileController.php
@@ -16,7 +16,6 @@ use Sulu\Bundle\ContactBundle\Entity\Address;
 use Sulu\Bundle\ContactBundle\Entity\AddressType;
 use Sulu\Bundle\ContactBundle\Entity\ContactAddress;
 use Sulu\Bundle\ContactBundle\Entity\Note;
-use Sulu\Bundle\MediaBundle\Api\Media;
 use Sulu\Bundle\SecurityBundle\Entity\User;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\Request;
@@ -27,6 +26,8 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class ProfileController extends AbstractController
 {
+    use SaveMediaTrait;
+
     const TYPE = Configuration::TYPE_PROFILE;
 
     /**
@@ -61,7 +62,7 @@ class ProfileController extends AbstractController
                 $user->setLocale($request->getLocale());
             }
 
-            $this->saveAvatar($form, $user, $request->getLocale());
+            $this->saveMediaFields($form, $user, $request->getLocale());
 
             // Register User
             $communityManager->saveProfile($user);
@@ -84,44 +85,6 @@ class ProfileController extends AbstractController
                 'success' => $success,
             ]
         );
-    }
-
-    /**
-     * Save media and set avatar on user.
-     *
-     * @param Form $form
-     * @param User $user
-     * @param string $locale
-     *
-     * @return Media|null
-     */
-    protected function saveAvatar(Form $form, User $user, $locale)
-    {
-        $uploadedFile = $form->get('contact')->get('avatar')->getData();
-        if (null === $uploadedFile) {
-            return null;
-        }
-
-        $systemCollectionManager = $this->get('sulu_media.system_collections.manager');
-        $mediaManager = $this->get('sulu_media.media_manager');
-
-        $collection = $systemCollectionManager->getSystemCollection('sulu_contact.contact');
-        $avatar = $user->getContact()->getAvatar();
-
-        $apiMedia = $mediaManager->save(
-            $uploadedFile,
-            [
-                'id' => (null !== $avatar ? $avatar->getId() : null),
-                'locale' => $locale,
-                'title' => $user->getUsername(),
-                'collection' => $collection,
-            ],
-            $user->getId()
-        );
-
-        $user->getContact()->setAvatar($apiMedia->getEntity());
-
-        return $apiMedia;
     }
 
     /**

--- a/Controller/RegistrationController.php
+++ b/Controller/RegistrationController.php
@@ -21,6 +21,8 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class RegistrationController extends AbstractController
 {
+    use SaveMediaTrait;
+
     const TYPE = Configuration::TYPE_REGISTRATION;
 
     /**
@@ -52,6 +54,8 @@ class RegistrationController extends AbstractController
             if (!$user->getLocale()) {
                 $user->setLocale($request->getLocale());
             }
+
+            $this->saveMediaFields($form, $user, $request->getLocale());
 
             // Register User
             $user = $communityManager->register($user);

--- a/Controller/SaveMediaTrait.php
+++ b/Controller/SaveMediaTrait.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CommunityBundle\Controller;
+
+use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
+use Sulu\Bundle\SecurityBundle\Entity\User;
+use Sulu\Component\Media\SystemCollections\SystemCollectionManagerInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+trait SaveMediaTrait
+{
+    private function saveMediaFields(FormInterface $form, User $user, $locale)
+    {
+        $this->saveAvatar($form, $user, $locale);
+        $this->saveDocuments($form, $user, $locale);
+    }
+
+    private function saveDocuments(FormInterface $form, User $user, $locale)
+    {
+        if (!$form->has('contact') || !$form->get('contact')->has('medias')) {
+            return;
+        }
+
+        $uploadedFiles = $form->get('contact')->get('medias')->getData();
+
+        if (empty($uploadedFiles)) {
+            return null;
+        }
+
+        if (!is_array($uploadedFiles)) {
+            $uploadedFiles = [$uploadedFiles];
+        }
+
+        $contact = $user->getContact();
+        $apiMedias = [];
+
+        foreach ($uploadedFiles as $uploadedFile) {
+            $apiMedia = $this->saveMedia($uploadedFile, null, $locale, $user->getId());
+            $contact->addMedia($apiMedia->getEntity());
+            $apiMedias[] = $apiMedia;
+        }
+
+        return $apiMedias;
+    }
+
+    protected function saveAvatar(FormInterface $form, User $user, $locale)
+    {
+        if (!$form->has('contact') || !$form->get('contact')->has('avatar')) {
+            return;
+        }
+
+        $uploadedFile = $form->get('contact')->get('avatar')->getData();
+        if (null === $uploadedFile) {
+            return null;
+        }
+
+        $avatar = $user->getContact()->getAvatar();
+
+        $apiMedia = $this->saveMedia($uploadedFile, (null !== $avatar ? $avatar->getId() : null), $locale, $user->getId());
+
+        $user->getContact()->setAvatar($apiMedia->getEntity());
+
+        return $apiMedia;
+    }
+
+    private function saveMedia(UploadedFile $uploadedFile, $id, $locale, $userId)
+    {
+        return $this->getMediaManager()->save(
+            $uploadedFile,
+            [
+                'id' => $id,
+                'locale' => $locale,
+                'title' => $uploadedFile->getClientOriginalName(),
+                'collection' => $this->getContactMediaCollection(),
+            ],
+            $userId
+        );
+    }
+
+    /**
+     * Get system collection manager.
+     *
+     * @return SystemCollectionManagerInterface
+     */
+    private function getSystemCollectionManager()
+    {
+        return $this->get('sulu_media.system_collections.manager');
+    }
+
+    /**
+     * Get media manager.
+     *
+     * @return MediaManagerInterface
+     */
+    private function getMediaManager()
+    {
+        return $this->get('sulu_media.media_manager');
+    }
+
+    /**
+     * Get contact media collection.
+     *
+     * @return int
+     */
+    private function getContactMediaCollection()
+    {
+        return $this->getSystemCollectionManager()->getSystemCollection('sulu_contact.contact');
+    }
+}

--- a/Tests/Unit/Controller/SaveMediaTraitTest.php
+++ b/Tests/Unit/Controller/SaveMediaTraitTest.php
@@ -1,0 +1,322 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CommunityBundle\Tests\Unit\Controller;
+
+use Sulu\Bundle\CommunityBundle\Controller\SaveMediaTrait;
+use Sulu\Bundle\ContactBundle\Entity\Contact;
+use Sulu\Bundle\MediaBundle\Api\Media as ApiMedia;
+use Sulu\Bundle\MediaBundle\Entity\Media;
+use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
+use Sulu\Bundle\SecurityBundle\Entity\User;
+use Sulu\Component\Media\SystemCollections\SystemCollectionManagerInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+class SaveMediaTraitTest extends \PHPUnit_Framework_TestCase
+{
+    use SaveMediaTrait {
+        getMediaManager as mockedGetMediaManager;
+        getSystemCollectionManager as mockedGetSystemCollectionManager;
+    }
+
+    /**
+     * @var MediaManagerInterface
+     */
+    private $mediaManager;
+
+    /**
+     * @var SystemCollectionManagerInterface
+     */
+    private $systemCollectionManager;
+
+    /**
+     * @var User
+     */
+    private $user;
+
+    /**
+     * @var string
+     */
+    private $locale;
+
+    /**
+     * @var FormInterface
+     */
+    private $form;
+
+    /**
+     * @var FormInterface
+     */
+    private $contactForm;
+
+    /**
+     * @var FormInterface
+     */
+    private $avatarForm;
+
+    /**
+     * @var FormInterface
+     */
+    private $mediasForm;
+
+    /**
+     * @var string[]
+     */
+    private $tempFilePaths = [];
+
+    /**
+     * @var Contact
+     */
+    private $contact;
+
+    /**
+     * @var Media
+     */
+    private $media;
+
+    /**
+     * @var ApiMedia
+     */
+    private $apiMedia;
+
+    protected function setUp()
+    {
+        $this->form = $this->prophesize(FormInterface::class);
+        $this->contactForm = $this->prophesize(FormInterface::class);
+        $this->avatarForm = $this->prophesize(FormInterface::class);
+        $this->mediasForm = $this->prophesize(FormInterface::class);
+        $this->contact = $this->prophesize(Contact::class);
+        $this->mediaManager = $this->prophesize(MediaManagerInterface::class);
+        $this->systemCollectionManager = $this->prophesize(SystemCollectionManagerInterface::class);
+        $this->user = $this->prophesize(User::class);
+        $this->media = $this->prophesize(Media::class);
+        $this->media->getId()->willReturn(3);
+        $this->apiMedia = $this->prophesize(ApiMedia::class);
+        $this->apiMedia->getEntity()->willReturn($this->media->reveal());
+        $this->user->getContact()->willReturn($this->contact->reveal());
+        $this->locale = 'de';
+    }
+
+    protected function tearDown()
+    {
+        foreach ($this->tempFilePaths as $tempFilePath) {
+            unlink($tempFilePath);
+        }
+    }
+
+    public function testNoContact()
+    {
+        $this->form->has('contact')->willReturn(false)->shouldBeCalled();
+        $this->form->get('contact')->shouldNotBeCalled();
+
+        $this->saveMediaFields($this->form->reveal(), $this->user->reveal(), $this->locale);
+    }
+
+    public function testNoAvatarAndNoMedias()
+    {
+        $this->form->has('contact')->willReturn(true)->shouldBeCalled();
+        $this->contactForm->has('avatar')->willReturn(false)->shouldBeCalled();
+        $this->contactForm->get('avatar')->shouldNotBeCalled();
+        $this->contactForm->has('medias')->willReturn(false)->shouldBeCalled();
+        $this->contactForm->get('medias')->shouldNotBeCalled();
+        $this->form->get('contact')->willReturn($this->contactForm->reveal());
+
+        $this->saveMediaFields($this->form->reveal(), $this->user->reveal(), $this->locale);
+    }
+
+    public function testAvatarAndNoMedias()
+    {
+        $this->contact->setAvatar($this->media->reveal())->shouldBeCalled();
+
+        $this->tempFilePaths[] = tempnam(sys_get_temp_dir(), 'sulu_community_test_media');
+        $uploadedFile = new UploadedFile($this->tempFilePaths[0], 'test.jpg');
+
+        $this->user->getId()->willReturn(1)->shouldBeCalled();
+        $this->contact->getAvatar()->willReturn(null)->shouldBeCalled();
+
+        $this->form->has('contact')->willReturn(true)->shouldBeCalled();
+        $this->contactForm->has('medias')->willReturn(false)->shouldBeCalled();
+        $this->contactForm->get('medias')->shouldNotBeCalled();
+        $this->contactForm->has('avatar')->willReturn(true)->shouldBeCalled();
+        $this->avatarForm->getData()->willReturn($uploadedFile)->shouldBeCalled();
+        $this->contactForm->get('avatar')->willReturn($this->avatarForm->reveal())->shouldBeCalled();
+        $this->form->get('contact')->willReturn($this->contactForm->reveal());
+
+        $this->systemCollectionManager->getSystemCollection('sulu_contact.contact')->willReturn(2)->shouldBeCalled();
+
+        $this->mediaManager->save(
+            $uploadedFile,
+            [
+                'id' => null,
+                'locale' => 'de',
+                'title' => 'test.jpg',
+                'collection' => 2,
+            ],
+            1
+        )->shouldBeCalled()->willReturn($this->apiMedia->reveal());
+
+        $this->saveMediaFields($this->form->reveal(), $this->user->reveal(), $this->locale);
+    }
+
+    public function testNoAvatarAndSingleMedia()
+    {
+        $this->contact->addMedia($this->media->reveal())->shouldBeCalled();
+
+        $this->tempFilePaths[] = tempnam(sys_get_temp_dir(), 'sulu_community_test_media');
+        $uploadedFile = new UploadedFile($this->tempFilePaths[0], 'test.jpg');
+
+        $this->user->getId()->willReturn(1)->shouldBeCalled();
+        $this->contact->getAvatar()->shouldNotBeCalled();
+
+        $this->form->has('contact')->willReturn(true)->shouldBeCalled();
+        $this->contactForm->has('medias')->willReturn(true)->shouldBeCalled();
+        $this->contactForm->get('medias')->willReturn($this->mediasForm->reveal());
+        $this->mediasForm->getData()->willReturn($uploadedFile)->shouldBeCalled();
+        $this->contactForm->has('avatar')->willReturn(false)->shouldBeCalled();
+        $this->contactForm->get('avatar')->shouldNotBeCalled();
+        $this->form->get('contact')->willReturn($this->contactForm->reveal());
+
+        $this->systemCollectionManager->getSystemCollection('sulu_contact.contact')->willReturn(2)->shouldBeCalled();
+
+        $this->mediaManager->save(
+            $uploadedFile,
+            [
+                'id' => null,
+                'locale' => 'de',
+                'title' => 'test.jpg',
+                'collection' => 2,
+            ],
+            1
+        )->shouldBeCalled()->willReturn($this->apiMedia->reveal());
+
+        $this->saveMediaFields($this->form->reveal(), $this->user->reveal(), $this->locale);
+    }
+
+    public function testNoAvatarAndMultipleMedias()
+    {
+        $this->contact->addMedia($this->media->reveal())->shouldBeCalled();
+
+        $this->tempFilePaths[] = tempnam(sys_get_temp_dir(), 'sulu_community_test_media');
+        $this->tempFilePaths[] = tempnam(sys_get_temp_dir(), 'sulu_community_test_media');
+        $uploadedFile = new UploadedFile($this->tempFilePaths[0], 'test.jpg');
+        $uploadedFile2 = new UploadedFile($this->tempFilePaths[1], 'test2.jpg');
+
+        $this->user->getId()->willReturn(1)->shouldBeCalled();
+        $this->contact->getAvatar()->shouldNotBeCalled();
+
+        $this->form->has('contact')->willReturn(true)->shouldBeCalled();
+        $this->contactForm->has('medias')->willReturn(true)->shouldBeCalled();
+        $this->contactForm->get('medias')->willReturn($this->mediasForm->reveal());
+        $this->mediasForm->getData()->willReturn([$uploadedFile, $uploadedFile2])->shouldBeCalled();
+        $this->contactForm->has('avatar')->willReturn(false)->shouldBeCalled();
+        $this->contactForm->get('avatar')->shouldNotBeCalled();
+        $this->form->get('contact')->willReturn($this->contactForm->reveal());
+
+        $this->systemCollectionManager->getSystemCollection('sulu_contact.contact')->willReturn(2)->shouldBeCalled();
+
+        $this->mediaManager->save(
+            $uploadedFile,
+            [
+                'id' => null,
+                'locale' => 'de',
+                'title' => 'test.jpg',
+                'collection' => 2,
+            ],
+            1
+        )->shouldBeCalled()->willReturn($this->apiMedia->reveal());
+
+        $this->mediaManager->save(
+            $uploadedFile2,
+            [
+                'id' => null,
+                'locale' => 'de',
+                'title' => 'test2.jpg',
+                'collection' => 2,
+            ],
+            1
+        )->shouldBeCalled()->willReturn($this->apiMedia->reveal());
+
+        $this->saveMediaFields($this->form->reveal(), $this->user->reveal(), $this->locale);
+    }
+
+    public function testAvatarAndMultipleMedias()
+    {
+        $this->contact->setAvatar($this->media->reveal())->shouldBeCalled();
+        $this->contact->addMedia($this->media->reveal())->shouldBeCalled();
+
+        $this->tempFilePaths[] = tempnam(sys_get_temp_dir(), 'sulu_community_test_media');
+        $this->tempFilePaths[] = tempnam(sys_get_temp_dir(), 'sulu_community_test_media');
+        $this->tempFilePaths[] = tempnam(sys_get_temp_dir(), 'sulu_community_test_media');
+        $uploadedFile = new UploadedFile($this->tempFilePaths[0], 'test.jpg');
+        $uploadedFile2 = new UploadedFile($this->tempFilePaths[1], 'test2.jpg');
+        $uploadedFile3 = new UploadedFile($this->tempFilePaths[1], 'test3.jpg');
+
+        $this->user->getId()->willReturn(1)->shouldBeCalled();
+        $this->contact->getAvatar()->willReturn($this->media->reveal())->shouldBeCalled();
+
+        $this->form->has('contact')->willReturn(true)->shouldBeCalled();
+        $this->contactForm->has('medias')->willReturn(true)->shouldBeCalled();
+        $this->contactForm->get('medias')->willReturn($this->mediasForm->reveal());
+        $this->mediasForm->getData()->willReturn([$uploadedFile, $uploadedFile2])->shouldBeCalled();
+        $this->contactForm->has('avatar')->willReturn(true)->shouldBeCalled();
+        $this->avatarForm->getData()->willReturn($uploadedFile3)->shouldBeCalled();
+        $this->contactForm->get('avatar')->willReturn($this->avatarForm->reveal())->shouldBeCalled();
+        $this->form->get('contact')->willReturn($this->contactForm->reveal());
+
+        $this->systemCollectionManager->getSystemCollection('sulu_contact.contact')->willReturn(2)->shouldBeCalled();
+
+        $this->mediaManager->save(
+            $uploadedFile,
+            [
+                'id' => null,
+                'locale' => 'de',
+                'title' => 'test.jpg',
+                'collection' => 2,
+            ],
+            1
+        )->shouldBeCalled()->willReturn($this->apiMedia->reveal());
+
+        $this->mediaManager->save(
+            $uploadedFile2,
+            [
+                'id' => null,
+                'locale' => 'de',
+                'title' => 'test2.jpg',
+                'collection' => 2,
+            ],
+            1
+        )->shouldBeCalled()->willReturn($this->apiMedia->reveal());
+
+        $this->mediaManager->save(
+            $uploadedFile3,
+            [
+                'id' => 3,
+                'locale' => 'de',
+                'title' => 'test3.jpg',
+                'collection' => 2,
+            ],
+            1
+        )->shouldBeCalled()->willReturn($this->apiMedia->reveal());
+
+        $this->saveMediaFields($this->form->reveal(), $this->user->reveal(), $this->locale);
+    }
+
+    private function getMediaManager()
+    {
+        return $this->mediaManager->reveal();
+    }
+
+    private function getSystemCollectionManager()
+    {
+        return $this->systemCollectionManager->reveal();
+    }
+}

--- a/Tests/app/AppKernel.php
+++ b/Tests/app/AppKernel.php
@@ -31,13 +31,19 @@ class AppKernel extends SuluTestKernel
      */
     public function registerBundles()
     {
-        return array_merge(
+        $bundles = array_merge(
             [
                 new SuluCommunityBundle(),
                 new SwiftmailerBundle(),
             ],
             parent::registerBundles()
         );
+
+        if ($this->getContext() === self::CONTEXT_WEBSITE) {
+            $bundles[] = new \Symfony\Bundle\SecurityBundle\SecurityBundle();
+        }
+
+        return $bundles;
     }
 
     /**

--- a/Tests/app/AppKernel.php
+++ b/Tests/app/AppKernel.php
@@ -39,7 +39,7 @@ class AppKernel extends SuluTestKernel
             parent::registerBundles()
         );
 
-        if ($this->getContext() === self::CONTEXT_WEBSITE) {
+        if (self::CONTEXT_WEBSITE === $this->getContext()) {
             $bundles[] = new \Symfony\Bundle\SecurityBundle\SecurityBundle();
         }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Related PRs | https://github.com/sulu/sulu/pull/4092
| License | MIT

#### What's in this PR?

Added contact documents upload and fixed profile without avatar.

#### Why?

Sometimes you want to allow that a community user can upload files to its contact.

#### Example Usage

~~~php
            $builder->add(
                'medias',
                FileType::class,
                [
                    'label' => 'attendance_confirmation',
                    'mapped' => false,
                    'required' => false,
                    'multiple' => true,
                ]
            );
~~~

#### BC Breaks/Deprecations

Did keep the saveAvatar function to avoid any bc breaks.


