### PR TITLE
Fix profile without note for mysql 5.7

### DIFF
--- a/Controller/ProfileController.php
+++ b/Controller/ProfileController.php
@@ -172,6 +172,7 @@ class ProfileController extends AbstractController
     private function addNote(User $user)
     {
         $note = new Note();
+        $note->setValue('');
         $user->getContact()->addNote($note);
 
         $this->get('doctrine.orm.entity_manager')->persist($note);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Fix profile without a note value.

#### Why?

Currently it will throw an insert error on mysql 5.7 when a profile without a note is submitted.

