### PR TITLE
Added registry for community-manager

### DIFF
--- a/Command/InitCommand.php
+++ b/Command/InitCommand.php
@@ -12,9 +12,8 @@
 namespace Sulu\Bundle\CommunityBundle\Command;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Sulu\Bundle\CommunityBundle\DependencyInjection\CompilerPass\Normalizer;
 use Sulu\Bundle\CommunityBundle\DependencyInjection\Configuration;
-use Sulu\Bundle\CommunityBundle\Manager\CommunityManagerInterface;
+use Sulu\Bundle\CommunityBundle\Manager\CommunityManagerRegistryInterface;
 use Sulu\Bundle\SecurityBundle\Entity\Role;
 use Sulu\Bundle\SecurityBundle\Entity\RoleRepository;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
@@ -79,14 +78,14 @@ class InitCommand extends ContainerAwareCommand
     {
         $webspaceKey = $webspace->getKey();
 
-        $communityServiceName = sprintf('sulu_community.%s.community_manager', Normalizer::normalize($webspaceKey));
+        /** @var CommunityManagerRegistryInterface $registry */
+        $registry = $this->getContainer()->get('sulu_community.community_manager.registry');
 
-        if (!$webspace->getSecurity() || !$this->getContainer()->has($communityServiceName)) {
+        if (!$webspace->getSecurity() || !$registry->has($webspaceKey)) {
             return;
         }
 
-        /** @var CommunityManagerInterface $communityManager */
-        $communityManager = $this->getContainer()->get($communityServiceName);
+        $communityManager = $registry->get($webspaceKey);
         $roleName = $communityManager->getConfigProperty(Configuration::ROLE);
         $system = $webspace->getSecurity()->getSystem();
 

--- a/Controller/AbstractController.php
+++ b/Controller/AbstractController.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Bundle\CommunityBundle\Controller;
 
-use Sulu\Bundle\CommunityBundle\DependencyInjection\CompilerPass\Normalizer;
 use Sulu\Bundle\CommunityBundle\DependencyInjection\Configuration;
 use Sulu\Bundle\CommunityBundle\Manager\CommunityManagerInterface;
 use Sulu\Bundle\SecurityBundle\Entity\User;
@@ -43,13 +42,7 @@ abstract class AbstractController extends Controller
      */
     protected function getCommunityManager($webspaceKey)
     {
-        if (!isset($this->communityManagers[$webspaceKey])) {
-            $this->communityManagers[$webspaceKey] = $this->get(
-                sprintf('sulu_community.%s.community_manager', Normalizer::normalize($webspaceKey))
-            );
-        }
-
-        return $this->communityManagers[$webspaceKey];
+        return $this->get('sulu_community.community_manager.registry')->get($webspaceKey);
     }
 
     /**

--- a/Manager/CommunityManagerRegistry.php
+++ b/Manager/CommunityManagerRegistry.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CommunityBundle\Manager;
+
+class CommunityManagerRegistry implements CommunityManagerRegistryInterface
+{
+    /**
+     * @var array
+     */
+    private $managers;
+
+    /**
+     * @param CommunityManagerInterface[] $managers
+     */
+    public function __construct(array $managers = [])
+    {
+        $this->managers = $managers;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get($webspaceKey)
+    {
+        if (!$this->has($webspaceKey)) {
+            throw new \Exception(
+                sprintf(
+                    'Webspace "%s" is not configured.',
+                    $webspaceKey
+                )
+            );
+        }
+
+        return $this->managers[$webspaceKey];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has($webspaceKey)
+    {
+        return array_key_exists($webspaceKey, $this->managers);
+    }
+}

--- a/Manager/CommunityManagerRegistryInterface.php
+++ b/Manager/CommunityManagerRegistryInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CommunityBundle\Manager;
+
+interface CommunityManagerRegistryInterface
+{
+    /**
+     * @param string $webspaceKey
+     *
+     * @return CommunityManagerInterface
+     */
+    public function get($webspaceKey);
+
+    /**
+     * @param string $webspaceKey
+     *
+     * @return bool
+     */
+    public function has($webspaceKey);
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -16,6 +16,11 @@
 
     <services>
         <!-- Community Manager -->
+        <service id="sulu_community.community_manager.registry"
+                 class="Sulu\Bundle\CommunityBundle\Manager\CommunityManagerRegistry"
+                 public="true">
+            <argument type="collection"/>
+        </service>
         <service id="sulu_community.community_manager"
                  class="Sulu\Bundle\CommunityBundle\Manager\CommunityManager"
                  abstract="true">

--- a/Tests/Unit/Manager/CommunityManagerRegistryTest.php
+++ b/Tests/Unit/Manager/CommunityManagerRegistryTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CommunityBundle\Tests\Unit\Manager;
+
+use Sulu\Bundle\CommunityBundle\Manager\CommunityManager;
+use Sulu\Bundle\CommunityBundle\Manager\CommunityManagerRegistry;
+
+class CommunityManagerRegistryTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGet()
+    {
+        $manager = $this->prophesize(CommunityManager::class);
+        $registry = new CommunityManagerRegistry(['sulu_io' => $manager->reveal()]);
+
+        $this->assertEquals($manager->reveal(), $registry->get('sulu_io'));
+    }
+
+    public function testGetNotExists()
+    {
+        $this->setExpectedException(\Exception::class);
+
+        $registry = new CommunityManagerRegistry();
+
+        $registry->get('sulu_io');
+    }
+
+    public function testHas()
+    {
+        $manager = $this->prophesize(CommunityManager::class);
+        $registry = new CommunityManagerRegistry(['sulu_io' => $manager->reveal()]);
+
+        $this->assertTrue($registry->has('sulu_io'));
+        $this->assertFalse($registry->has('test_io'));
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | non
| License | MIT

#### What's in this PR?

This PR introduces a registry for the community-managers (webspace specific).

#### Why?

This replaces the handling of ids inside of the controller or other extensions.