### PR TITLE
Fix composer deprecation and upgrade ci to php 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,16 @@ cache:
   directories:
     - "$HOME/.composer/cache"
 
+env:
+  global:
+      - SYMFONY__DATABASE__VERSION=5.5.39
+
 matrix:
   include:
     - php: 5.5
       env:
         - COMPOSER_FLAGS="--prefer-dist --no-interaction" # --prefer-lowest not possible in sulu 1.3
-    - php: 7.0
+    - php: 7.3
       env:
         - COMPOSER_FLAGS="--prefer-dist --no-interaction"
         - CODE_COVERAGE=true
@@ -22,7 +26,9 @@ before_install:
   - composer self-update
 
 install:
-  - if [[ $PHPSTAN == 'true' ]]; then travis_retry composer require --dev phpstan/phpstan $COMPOSER_FLAGS ; else travis_retry composer update $COMPOSER_FLAGS ; fi
+  - if [[ $PHPSTAN == 'true' ]]; then travis_retry composer require --dev phpstan/phpstan --no-update ; fi
+  - composer update $COMPOSER_FLAGS
+  - composer validate --strict
   - composer info -i
   - ./Tests/app/console doctrine:database:create
   - ./Tests/app/console doctrine:schema:update --force

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "sulu/sulu": "^1.3",
         "massive/build-bundle": "^0.2 || ^0.3",
         "symfony/swiftmailer-bundle": "~2.3",
-        "beberlei/DoctrineExtensions": "^1.0"
+        "beberlei/doctrineextensions": "^1.0"
     },
     "require-dev": {
         "jackalope/jackalope-doctrine-dbal": "^1.2.5",
@@ -18,7 +18,8 @@
         "massive/search-bundle": "@dev",
         "zendframework/zend-stdlib": "~2.3",
         "zendframework/zendsearch": "@dev",
-        "phpunit/phpunit": ">=4.8, <6.0"
+        "phpunit/phpunit": ">=4.8, <6.0",
+        "doctrine/data-fixtures": "^1.0"
     },
     "keywords": [
         "registration",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Fix composer deprecation and upgrade ci to php 7.3

#### Why?

> Deprecation warning: require.beberlei/DoctrineExtensions is invalid, it should not contain uppercase characters. Please use beberlei/doctrineextensions instead. Make sure you fix this as Composer 2.0 will error

And to test community bundle on php 73
