### PR TITLE
Fix initializing of webspaces with same role name

### DIFF
--- a/Command/InitCommand.php
+++ b/Command/InitCommand.php
@@ -82,9 +82,8 @@ class InitCommand extends ContainerAwareCommand
         /** @var Webspace $webspace */
         foreach ($this->webspaceManager->getWebspaceCollection() as $webspace) {
             $this->initWebspace($webspace, $output);
+            $this->entityManager->flush();
         }
-
-        $this->entityManager->flush();
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR adjusts the `InitCommand` to call flush on the `EntityManager` after initializing a webspace.

#### Why?

Because this way it is possible to configure the same role for multiple Webspaces. Otherwise the created role is not flushed and therefore created again during the initialization of the second Webspace. This leads to a `Doctrine\DBAL\Exception\UniqueConstraintViolationException`.

