### PR TITLE
Add 'useAttributeAsKey' to webspaces config node

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -105,6 +105,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->arrayNode('webspaces')
                     ->normalizeKeys(false)
+                    ->useAttributeAsKey('webspaceKey')
                     ->prototype('array')
                         ->children()
                             // Basic Webspace Configuration


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes none
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

This PR set `useAttributeAsKey` to allow splitting the webspaces config.

#### Why?

If you split the config for webspaces into multiple files.
