### PR TITLE
Fix maintenance mode with env variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: trusty
 
 language: php
 

--- a/Controller/AbstractController.php
+++ b/Controller/AbstractController.php
@@ -20,6 +20,7 @@ use Sulu\Bundle\SecurityBundle\Entity\User;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 /**
  * Contains helper function for all controllers.
@@ -147,8 +148,11 @@ abstract class AbstractController extends Controller
      */
     public function getUser()
     {
-        /** @var User $user */
         $user = parent::getUser();
+
+        if (!$user instanceof User) {
+            throw new HttpException(403);
+        }
 
         if (null === $user->getContact()->getMainAddress()) {
             // TODO this should be done by the form type not by the controller

--- a/DependencyInjection/CompilerPass/CommunityManagerCompilerPass.php
+++ b/DependencyInjection/CompilerPass/CommunityManagerCompilerPass.php
@@ -31,7 +31,7 @@ class CommunityManagerCompilerPass implements CompilerPassInterface
 
         $references = [];
         foreach ($webspacesConfig as $webspaceKey => $webspaceConfig) {
-            $webspaceConfig = $this->updateWebspaceConfig($webspaceKey, $webspaceConfig);
+            $webspaceConfig = $this->updateWebspaceConfig($container, $webspaceKey, $webspaceConfig);
             $webspacesConfig[$webspaceKey] = $webspaceConfig;
 
             $definition = new ChildDefinition('sulu_community.community_manager');
@@ -57,12 +57,13 @@ class CommunityManagerCompilerPass implements CompilerPassInterface
     /**
      * Update webspace config.
      *
+     * @param ContainerBuilder $container
      * @param string $webspaceKey
      * @param array $webspaceConfig
      *
      * @return array
      */
-    private function updateWebspaceConfig($webspaceKey, array $webspaceConfig)
+    private function updateWebspaceConfig(ContainerBuilder $container, $webspaceKey, array $webspaceConfig)
     {
         // Set firewall by webspace key
         if (null === $webspaceConfig[Configuration::FIREWALL]) {
@@ -95,8 +96,13 @@ class CommunityManagerCompilerPass implements CompilerPassInterface
             $webspaceConfig[Configuration::EMAIL_TO] = $webspaceConfig[Configuration::EMAIL_FROM];
         }
 
-        // Set maintenance mode
-        if ($webspaceConfig[Configuration::MAINTENANCE][Configuration::ENABLED]) {
+        // TODO maintenance mode should not be handled in compilerpass
+        $maintenanceEnabled = $container->resolveEnvPlaceholders(
+            $webspaceConfig[Configuration::MAINTENANCE][Configuration::ENABLED],
+            true
+        );
+
+        if ($maintenanceEnabled) {
             $webspaceConfig = $this->activateMaintenanceMode($webspaceConfig);
         }
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -145,7 +145,7 @@ class Configuration implements ConfigurationInterface
                             ->arrayNode(self::MAINTENANCE)
                                 ->canBeEnabled()
                                 ->children()
-                                    ->scalarNode(self::TEMPLATE)->defaultValue('SuluCommunityBundle:Maintenance:maintenance.html.twig')->end()
+                                    ->scalarNode(self::TEMPLATE)->defaultValue('@SuluCommunity/maintenance.html.twig')->end()
                                 ->end()
                             ->end()
                             // Login

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "jackalope/jackalope-doctrine-dbal": "^1.2.5",
-        "jangregor/phpstan-prophecy": "^0.3",
+        "jangregor/phpstan-prophecy": "^0.4",
         "massive/search-bundle": "@dev",
         "phpstan/phpstan": "^0.11",
         "phpstan/phpstan-doctrine": "^0.11",
@@ -69,7 +69,10 @@
         "lint": [
             "@phpstan"
         ],
-        "phpstan": "vendor/bin/phpstan analyse ./ -c phpstan.neon"
+        "phpstan": [
+            "Tests/Application/bin/adminconsole cache:warmup",
+            "vendor/bin/phpstan analyse ./ -c phpstan.neon"
+        ]
     },
     "extra": {
         "branch-alias": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,3 +11,5 @@ parameters:
         - %currentWorkingDirectory%/Tests/*
     symfony:
         container_xml_path: %currentWorkingDirectory%/Tests/Application/var/cache/admin/dev/adminAdminDevDebugProjectContainer.xml
+    ignoreErrors:
+        - '#Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface::dispatch()#'


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

Fix maintenance mode with env variables.

#### Why?

Env Variables need to be resolved when being used when building the container.

#### Example Usage

~~~yaml
# config.yaml
sulu_community:
    webspaces:
        test:
            maintenance:
                enabled: "%env(bool:COMMUNITY_MAINTENANCE)%"
~~~

~~~env
COMMUNITY_MAINTENANCE=false
~~~

