### PR TITLE
Fix completion listener and completion validator services

### DIFF
--- a/EventListener/CompletionListener.php
+++ b/EventListener/CompletionListener.php
@@ -11,15 +11,15 @@
 
 namespace Sulu\Bundle\CommunityBundle\EventListener;
 
-use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
 use Sulu\Bundle\CommunityBundle\Validator\User\CompletionInterface;
 use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Routing\RouterInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 /**
@@ -38,7 +38,7 @@ class CompletionListener implements EventSubscriberInterface
     protected $router;
 
     /**
-     * @var TokenStorage
+     * @var TokenStorageInterface
      */
     protected $tokenStorage;
 
@@ -60,7 +60,7 @@ class CompletionListener implements EventSubscriberInterface
     public function __construct(
         RequestAnalyzerInterface $requestAnalyzer,
         RouterInterface $router,
-        TokenStorage $tokenStorage,
+        TokenStorageInterface $tokenStorage,
         string $fragmentPath,
         array $validators
     ) {

--- a/Resources/doc/11-completion.md
+++ b/Resources/doc/11-completion.md
@@ -16,7 +16,7 @@ sulu_community:
                     user_template: ~
                     admin_template: ~
                 redirect_to: /
-                service: app.completion_validator
+                service: App\Community\CompletionValidator
                 template: community/completion-form.html.twig
                 type: App\Form\CompletionType
 ```
@@ -40,9 +40,9 @@ It is possible that an email is also sent after the completion.
 The service which validates the user data and checks if a completion form should be displayed.
 
 ```php
-// src/Validator/CompletionValidator.php
+// src/Community/CompletionValidator.php
 
-namespace App\Validator;
+namespace App\Community;
 
 use Sulu\Bundle\CommunityBundle\Validator\User\CompletionInterface;
 use Sulu\Bundle\SecurityBundle\Entity\User;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

Fix completion listener service.

#### Why?

Currently the completion listener errors with that not the correct interface is implemented for EventSubscriber and that you will get under dev UsageTrackingTokenStorage instead of TokenStorage.

#### Example Usage

Activate the completion listener.

