### PR TITLE
Check for firewall name in completion listener

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -72,6 +72,7 @@
             <argument type="service" id="security.token_storage"/>
             <argument>%fragment.path%</argument>
             <argument type="collection"/>
+            <argument>%sulu_community.webspaces_config%</argument>
 
             <tag name="kernel.event_subscriber"/>
             <tag name="sulu.context" context="website"/>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

Check for firewall name in completion listener.

#### Why?

Currently the detection will be done on all firewalls but it should only effect the configured firewall in the sulu_community config.

#### Example Usage

~~~yaml
sulu_community:
    webspaces:
        <webspace_key>:
            firewall: 'extranet' # if not configured the firewall name will be the webspace_key which should be used in the security_website.yaml
~~~

