### PR TITLE
Fix registration error caused by a non-existing role name.

### DIFF
--- a/Manager/UserManager.php
+++ b/Manager/UserManager.php
@@ -180,7 +180,7 @@ class UserManager implements UserManagerInterface
     protected function createUserRole(User $user, string $webspaceKey, string $roleName): UserRole
     {
         /** @var RoleInterface $role */
-        $role = $this->roleRepository->findOneBy(['name' => $roleName]);
+        $role = $this->roleRepository->findOneBy(['key' => $roleName]);
         $userRole = new UserRole();
 
         $locales = [];

--- a/Manager/UserManager.php
+++ b/Manager/UserManager.php
@@ -164,7 +164,7 @@ class UserManager implements UserManagerInterface
     protected function createUserRole(User $user, string $webspaceKey, string $roleName): UserRole
     {
         /** @var RoleInterface $role */
-        $role = $this->roleRepository->findOneBy(['name' => $roleName]);
+        $role = $this->roleRepository->findOneBy(['key' => $roleName]);
         $userRole = new UserRole();
 
         $locales = [];

--- a/Manager/UserManager.php
+++ b/Manager/UserManager.php
@@ -87,7 +87,7 @@ class UserManager implements UserManagerInterface
         $this->contactManager = $contactManager;
     }
 
-    public function createUser(User $user, string $webspaceKey, string $roleName): User
+    public function createUser(User $user, string $webspaceKey, string $roleKey): User
     {
         // User needs contact
         /** @var ContactInterface|null $contact */
@@ -102,7 +102,7 @@ class UserManager implements UserManagerInterface
         $user = $this->updateUser($user);
 
         // Create and Add User Role
-        $userRole = $this->createUserRole($user, $webspaceKey, $roleName);
+        $userRole = $this->createUserRole($user, $webspaceKey, $roleKey);
         $user->addUserRole($userRole);
 
         // Save Entity
@@ -161,10 +161,14 @@ class UserManager implements UserManagerInterface
     /**
      * Create a user roles add permissions for all webspace locales.
      */
-    protected function createUserRole(User $user, string $webspaceKey, string $roleName): UserRole
+    protected function createUserRole(User $user, string $webspaceKey, string $roleKey): UserRole
     {
-        /** @var RoleInterface $role */
-        $role = $this->roleRepository->findOneBy(['key' => $roleName]);
+        $role = $this->roleRepository->findOneBy(['key' => $roleKey]);
+
+        if (!$role instanceof RoleInterface) {
+            throw new \InvalidArgumentException(\sprintf('Role with key "%s" could not be found.', $roleKey));
+        }
+
         $userRole = new UserRole();
 
         $locales = [];

--- a/Manager/UserManagerInterface.php
+++ b/Manager/UserManagerInterface.php
@@ -21,7 +21,7 @@ interface UserManagerInterface
     /**
      * Create a new User entity.
      */
-    public function createUser(User $user, string $webspaceKey, string $roleName): User;
+    public function createUser(User $user, string $webspaceKey, string $roleKey): User;
 
     /**
      * Update User entity.

--- a/Tests/Functional/Controller/RegistrationTest.php
+++ b/Tests/Functional/Controller/RegistrationTest.php
@@ -50,6 +50,7 @@ class RegistrationTest extends SuluTestCase
 
         $role = new Role();
         $role->setName('Sulu-ioUser');
+        $role->setKey('Sulu-ioUser');
         $role->setSystem('Website');
 
         $emailType = new EmailType();

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -191,24 +191,16 @@ The name of the relation inside of the `_embedded` field has been changed from `
 
 ### User registration resolves the role by its key
 
-`UserManager::createUser()` and the protected `createUserRole()` now look the
-configured role up by its `key` instead of its `name`. The role `name` is a
-human-readable, editable label, so relying on it caused registrations to fail
-once the name was changed in the administration interface.
+`UserManager::createUser()` now resolves the configured role by its `key`
+instead of its (editable) `name`, and throws an `\InvalidArgumentException` when
+no matching role exists. Make sure the per-webspace `role` configuration matches
+the **key** of an existing role (`sulu:community:init` creates roles by key).
 
-Make sure the `role` configured per webspace matches the **key** of an existing
-role (the `sulu:community:init` command already creates roles by key). If no role
-matches the configured key an `\InvalidArgumentException` is now thrown instead
-of failing later with an opaque database error.
-
-The corresponding parameter of `UserManagerInterface::createUser()` was renamed
-from `$roleName` to `$roleKey`. This only affects callers using named arguments
-and classes implementing the interface:
+The `createUser()` parameter was renamed accordingly, affecting named-argument
+callers and implementations of `UserManagerInterface`:
 
 ```
-createUser(User $user, string $webspaceKey, string $roleName): User
-->
-createUser(User $user, string $webspaceKey, string $roleKey): User
+createUser(..., string $roleName) -> createUser(..., string $roleKey)
 ```
 
 ### Typehints added to the codebase

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -189,6 +189,28 @@ The name of the relation inside of the `_embedded` field has been changed from `
 
  - The model parameters have been changed from `sulu.model.blacklist_user.class` and `sulu.model.blacklist_item.class` to `sulu.model.registration_rule_user.class` and `sulu.model.registration_rule_item.class`.
 
+### User registration resolves the role by its key
+
+`UserManager::createUser()` and the protected `createUserRole()` now look the
+configured role up by its `key` instead of its `name`. The role `name` is a
+human-readable, editable label, so relying on it caused registrations to fail
+once the name was changed in the administration interface.
+
+Make sure the `role` configured per webspace matches the **key** of an existing
+role (the `sulu:community:init` command already creates roles by key). If no role
+matches the configured key an `\InvalidArgumentException` is now thrown instead
+of failing later with an opaque database error.
+
+The corresponding parameter of `UserManagerInterface::createUser()` was renamed
+from `$roleName` to `$roleKey`. This only affects callers using named arguments
+and classes implementing the interface:
+
+```
+createUser(User $user, string $webspaceKey, string $roleName): User
+->
+createUser(User $user, string $webspaceKey, string $roleKey): User
+```
+
 ### Typehints added to the codebase
 
 Everywhere were possible typehints were added to the classes and interfaces.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -661,7 +661,7 @@ parameters:
 			path: Manager/CommunityManager.php
 
 		-
-			message: '#^Parameter \#3 \$roleName of method Sulu\\Bundle\\CommunityBundle\\Manager\\UserManagerInterface\:\:createUser\(\) expects string, mixed given\.$#'
+			message: '#^Parameter \#3 \$roleKey of method Sulu\\Bundle\\CommunityBundle\\Manager\\UserManagerInterface\:\:createUser\(\) expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: Manager/CommunityManager.php


### PR DESCRIPTION
UserManager->createUserRole uses the role key instead of the role name to create a new user, because the role name should be only a human readable value and not a key

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

the commit-msg describes itself

#### Why?



