### PR TITLE
Catch Exception when no User is found

### DIFF
--- a/Manager/UserManager.php
+++ b/Manager/UserManager.php
@@ -239,7 +239,11 @@ class UserManager implements UserManagerInterface
      */
     public function findUser(string $identifier): ?User
     {
-        $user = $this->userRepository->findUserByIdentifier($identifier);
+        try {
+            $user = $this->userRepository->findUserByIdentifier($identifier);
+        } catch (NoResultException $e) {
+            return null;
+        }
 
         if (!$user instanceof User) {
             return null;

--- a/Manager/UserManager.php
+++ b/Manager/UserManager.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\CommunityBundle\Manager;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\NoResultException;
 use Sulu\Bundle\ContactBundle\Contact\ContactManagerInterface;
 use Sulu\Bundle\ContactBundle\Entity\ContactInterface;
 use Sulu\Bundle\ContactBundle\Entity\ContactRepositoryInterface;


### PR DESCRIPTION
If a function returns ?User, I expect it to return null if no User is found instead of throwing an Error.

| Bug fix? | yes
| Deprecations? | maybe?

#### What's in this PR?

catch an Exception that is not expected/documented to be thrown

#### BC Breaks/Deprecations

If someone catches this Exception in his* own code, this would not be called anymore

