### PR TITLE
Remove duplicated array key in example profile type

### DIFF
--- a/Resources/doc/9-profile.md
+++ b/Resources/doc/9-profile.md
@@ -98,7 +98,6 @@ class ProfileType extends AbstractType
                 'sulu_contact.female_form_of_address' => 1,
             ],
             'translation_domain' => 'admin',
-            'translation_domain' => 'backend',
             'expanded' => true,
         ]);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Remove duplicated array key in example profile type.

#### Why?

Should not be there twice.
