### PR TITLE
WIP: Change translation to url locale

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -90,6 +90,7 @@ class Configuration implements ConfigurationInterface
     // Other configurations
     const LAST_LOGIN = 'last_login';
     const REFRESH_INTERVAL = 'refresh_interval';
+    const USER_LOCALE_TRANSLATED = 'user_locale_translated';
 
     /**
      * {@inheritdoc}
@@ -126,6 +127,7 @@ class Configuration implements ConfigurationInterface
                         ->integerNode(self::REFRESH_INTERVAL)->defaultValue(600)->end()
                     ->end()
                 ->end()
+                ->booleanNode(self::USER_LOCALE_TRANSLATED)->defaultTrue()->end()
                 ->arrayNode('webspaces')
                     ->normalizeKeys(false)
                     ->useAttributeAsKey('webspaceKey')

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -90,7 +90,7 @@ class Configuration implements ConfigurationInterface
     // Other configurations
     const LAST_LOGIN = 'last_login';
     const REFRESH_INTERVAL = 'refresh_interval';
-    const USER_LOCALE_TRANSLATED = 'user_locale_translated';
+    const TRANSLATED_BY_USER_LOCALE = 'translated_by_user_locale';
 
     /**
      * {@inheritdoc}
@@ -127,7 +127,7 @@ class Configuration implements ConfigurationInterface
                         ->integerNode(self::REFRESH_INTERVAL)->defaultValue(600)->end()
                     ->end()
                 ->end()
-                ->booleanNode(self::USER_LOCALE_TRANSLATED)->defaultTrue()->end()
+                ->booleanNode(self::TRANSLATED_BY_USER_LOCALE)->defaultTrue()->end()
                 ->arrayNode('webspaces')
                     ->normalizeKeys(false)
                     ->useAttributeAsKey('webspaceKey')

--- a/DependencyInjection/SuluCommunityExtension.php
+++ b/DependencyInjection/SuluCommunityExtension.php
@@ -45,6 +45,9 @@ class SuluCommunityExtension extends Extension implements PrependExtensionInterf
         $loader->load('services.xml');
         $loader->load('validator.xml');
 
+        $userLocaleTranslated = $config[Configuration::USER_LOCALE_TRANSLATED];
+        $container->setParameter('sulu_community.user_locale_translated', $userLocaleTranslated);
+
         if ($lastLoginEnabled) {
             $lastLoginRefreshInterval = $config[Configuration::LAST_LOGIN][Configuration::REFRESH_INTERVAL];
 

--- a/DependencyInjection/SuluCommunityExtension.php
+++ b/DependencyInjection/SuluCommunityExtension.php
@@ -45,8 +45,8 @@ class SuluCommunityExtension extends Extension implements PrependExtensionInterf
         $loader->load('services.xml');
         $loader->load('validator.xml');
 
-        $userLocaleTranslated = $config[Configuration::USER_LOCALE_TRANSLATED];
-        $container->setParameter('sulu_community.user_locale_translated', $userLocaleTranslated);
+        $translatedByUserLocale = $config[Configuration::TRANSLATED_BY_USER_LOCALE];
+        $container->setParameter('sulu_community.translated_by_user_locale', $translatedByUserLocale);
 
         if ($lastLoginEnabled) {
             $lastLoginRefreshInterval = $config[Configuration::LAST_LOGIN][Configuration::REFRESH_INTERVAL];

--- a/Mail/MailFactory.php
+++ b/Mail/MailFactory.php
@@ -39,18 +39,18 @@ class MailFactory implements MailFactoryInterface
     /**
      * @var bool
      */
-    protected $userLocaleTranslated;
+    protected $translatedByUserLocale;
 
     public function __construct(
         \Swift_Mailer $mailer,
         Environment $twig,
         TranslatorInterface $translator,
-        bool $userLocaleTranslated
+        bool $translatedByUserLocale
     ) {
         $this->mailer = $mailer;
         $this->twig = $twig;
         $this->translator = $translator;
-        $this->userLocaleTranslated = $userLocaleTranslated;
+        $this->translatedByUserLocale = $translatedByUserLocale;
     }
 
     /**
@@ -71,7 +71,7 @@ class MailFactory implements MailFactoryInterface
             // Render Email in specific locale
             $locale = $translator->getLocale();
 
-            if ($this->userLocaleTranslated) {
+            if ($this->translatedByUserLocale) {
                 $translator->setLocale($user->getLocale());
             }
 

--- a/Mail/MailFactory.php
+++ b/Mail/MailFactory.php
@@ -36,11 +36,21 @@ class MailFactory implements MailFactoryInterface
      */
     protected $translator;
 
-    public function __construct(\Swift_Mailer $mailer, Environment $twig, TranslatorInterface $translator)
-    {
+    /**
+     * @var bool
+     */
+    protected $userLocaleTranslated;
+
+    public function __construct(
+        \Swift_Mailer $mailer,
+        Environment $twig,
+        TranslatorInterface $translator,
+        bool $userLocaleTranslated
+    ) {
         $this->mailer = $mailer;
         $this->twig = $twig;
         $this->translator = $translator;
+        $this->userLocaleTranslated = $userLocaleTranslated;
     }
 
     /**
@@ -60,7 +70,10 @@ class MailFactory implements MailFactoryInterface
             $translator = $this->translator;
             // Render Email in specific locale
             $locale = $translator->getLocale();
-            $translator->setLocale($user->getLocale());
+
+            if ($this->userLocaleTranslated) {
+                $translator->setLocale($user->getLocale());
+            }
 
             $this->sendEmail($mail->getFrom(), $email, $mail->getSubject(), $mail->getUserTemplate(), $data);
             $translator->setLocale($locale);

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -148,7 +148,7 @@
             <argument type="service" id="mailer"/>
             <argument type="service" id="twig"/>
             <argument type="service" id="translator"/>
-            <argument>%sulu_community.user_locale_translated%</argument>
+            <argument>%sulu_community.translated_by_user_locale%</argument>
         </service>
         <service id="Sulu\Bundle\CommunityBundle\Mail\MailFactoryInterface" alias="sulu_community.mail_factory"/>
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -148,6 +148,7 @@
             <argument type="service" id="mailer"/>
             <argument type="service" id="twig"/>
             <argument type="service" id="translator"/>
+            <argument>%sulu_community.user_locale_translated%</argument>
         </service>
         <service id="Sulu\Bundle\CommunityBundle\Mail\MailFactoryInterface" alias="sulu_community.mail_factory"/>
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

You can now decide via config if the emails are translated by user locale or url locale

#### Why?

if someone registers he does not set his locale but we used the locale in the url.

#### Example Usage

Add locale to your community routes and the emails will be translated by locale.

#### To Do

- [ ] Add Documentation

