### PR TITLE
Return HTTP 422 code when form is invalid

### DIFF
--- a/Controller/AbstractController.php
+++ b/Controller/AbstractController.php
@@ -106,9 +106,25 @@ abstract class AbstractController extends SymfonyAbstractController
             Configuration::TEMPLATE
         );
 
+        $response = new Response();
+
+        // Reuse logic from Symfony AbstractController.
+        // See: https://github.com/symfony/symfony/blob/6.3/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php#L239-L243
+        // See: https://github.com/symfony/symfony/blob/6.3/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php#L260-L265
+        foreach ($data as $k => $v) {
+            if ($v instanceof FormInterface) {
+                if ($v->isSubmitted() && !$v->isValid()) {
+                    $response->setStatusCode(422);
+                }
+
+                $data[$k] = $v->createView();
+            }
+        }
+
         return $this->render(
             $template,
-            $data
+            $data,
+            $response
         );
     }
 

--- a/Controller/CompletionController.php
+++ b/Controller/CompletionController.php
@@ -81,7 +81,7 @@ class CompletionController extends AbstractController
         return $this->renderTemplate(
             self::TYPE,
             [
-                'form' => $form->createView(),
+                'form' => $form,
                 'success' => $success,
             ]
         );

--- a/Controller/PasswordController.php
+++ b/Controller/PasswordController.php
@@ -67,7 +67,7 @@ class PasswordController extends AbstractController
         return $this->renderTemplate(
             Configuration::TYPE_PASSWORD_FORGET,
             [
-                'form' => $form->createView(),
+                'form' => $form,
                 'success' => $success,
             ]
         );
@@ -138,7 +138,7 @@ class PasswordController extends AbstractController
         return $this->renderTemplate(
             Configuration::TYPE_PASSWORD_RESET,
             [
-                'form' => $form->createView(),
+                'form' => $form,
                 'success' => $success,
             ]
         );

--- a/Controller/ProfileController.php
+++ b/Controller/ProfileController.php
@@ -73,7 +73,7 @@ class ProfileController extends AbstractController
         return $this->renderTemplate(
             self::TYPE,
             [
-                'form' => $form->createView(),
+                'form' => $form,
                 'success' => $success,
             ]
         );

--- a/Controller/RegistrationController.php
+++ b/Controller/RegistrationController.php
@@ -78,7 +78,7 @@ class RegistrationController extends AbstractController
         return $this->renderTemplate(
             self::TYPE,
             [
-                'form' => $form->createView(),
+                'form' => $form,
                 'success' => $success,
             ]
         );

--- a/Tests/Functional/Controller/ProfileControllerTest.php
+++ b/Tests/Functional/Controller/ProfileControllerTest.php
@@ -172,6 +172,19 @@ class ProfileControllerTest extends SuluTestCase
         $this->assertNull($user->getContact()->getNote());
     }
 
+    public function testProfileInvalid(): void
+    {
+        $crawler = $this->client->request('GET', '/profile');
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+
+        $form = $crawler->selectButton('profile[submit]')->form([
+            'profile[firstName]' => null,
+        ]);
+
+        $this->client->submit($form);
+        $this->assertHttpStatusCode(422, $this->client->getResponse());
+    }
+
     /**
      * @return array{
      *     'sulu.context': SuluKernel::CONTEXT_WEBSITE,

--- a/Tests/Functional/Controller/RegistrationTest.php
+++ b/Tests/Functional/Controller/RegistrationTest.php
@@ -92,6 +92,17 @@ class RegistrationTest extends SuluTestCase
         $this->assertHttpStatusCode(302, $this->client->getResponse());
     }
 
+    public function testRegisterInvalid(): void
+    {
+        $crawler = $this->client->request('GET', '/registration');
+
+        $form = $crawler->selectButton('registration[submit]')->form([
+            'registration[username]' => null,
+        ]);
+        $this->client->submit($form);
+        $this->assertHttpStatusCode(422, $this->client->getResponse());
+    }
+
     public function testConfirmation(): User
     {
         $this->testRegister();
@@ -173,7 +184,7 @@ class RegistrationTest extends SuluTestCase
             ]
         );
         $this->client->submit($form);
-        $this->assertHttpStatusCode(200, $this->client->getResponse());
+        $this->assertHttpStatusCode(422, $this->client->getResponse());
         $content = $this->client->getResponse()->getContent();
 
         $this->assertIsString($content);
@@ -332,6 +343,17 @@ class RegistrationTest extends SuluTestCase
         $password = $user->getPassword();
         $this->assertNotNull($password);
         $this->assertStringStartsWith('my-new-password', $password);
+    }
+
+    public function testPasswordForgetInvalid(): void
+    {
+        $crawler = $this->client->request('GET', '/password-forget');
+
+        $form = $crawler->selectButton('password_forget[submit]')->form([
+            'password_forget[email_username]' => 'hikaru@sulu.io',
+        ]);
+        $this->client->submit($form);
+        $this->assertHttpStatusCode(422, $this->client->getResponse());
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #165
| License | MIT

#### What's in this PR?

This PR fixes the invalid form return code, which should be HTTP 422.
It also updates the test suite and creates some new assertions.

Redo of #166