### PR TITLE
Fixing workflow badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
         <img src="https://img.shields.io/github/license/sulu/SuluCommunityBundle.svg" alt="GitHub license">
     </a>
     <a href="https://github.com/sulu/SuluCommunityBundle/actions" target="_blank">
-        <img src="https://img.shields.io/github/workflow/status/sulu/SuluCommunityBundle/Test%20application?label=test-workflow" alt="Test workflow status">
+        <img src="https://img.shields.io/github/actions/workflow/status/sulu/SuluCommunityBundle/test-application.yaml" alt="Test workflow status">
     </a>
     <a href="https://github.com/sulu/sulu/releases" target="_blank">
         <img src="https://img.shields.io/badge/sulu%20compatibility-%3E=2.0-52b6ca.svg" alt="Sulu compatibility">


### PR DESCRIPTION
Refs sulu/sulu#7010

Note this doesn't have a specific branch name specified. Adding a `?branch=2.0` will make the bade stop working:
<img src="https://img.shields.io/github/actions/workflow/status/sulu/SuluCommunityBundle/test-application.yaml?branch=2.0" alt="Test workflow status">

## Example

<img src="https://img.shields.io/github/actions/workflow/status/sulu/SuluCommunityBundle/test-application.yaml" alt="Test workflow status">