### PR TITLE
Replacing rest routes with symfony routes

### DIFF
--- a/Controller/BlacklistItemController.php
+++ b/Controller/BlacklistItemController.php
@@ -12,9 +12,6 @@
 namespace Sulu\Bundle\CommunityBundle\Controller;
 
 use Doctrine\ORM\EntityManagerInterface;
-use FOS\RestBundle\Controller\Annotations\NamePrefix;
-use FOS\RestBundle\Controller\Annotations\RouteResource;
-use FOS\RestBundle\Routing\ClassResourceInterface;
 use FOS\RestBundle\View\ViewHandlerInterface;
 use Sulu\Bundle\CommunityBundle\Entity\BlacklistItem;
 use Sulu\Bundle\CommunityBundle\Manager\BlacklistItemManagerInterface;
@@ -32,12 +29,8 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 
 /**
  * Provides admin-api for blacklist-items.
- *
- * @NamePrefix("sulu_community.")
- *
- * @RouteResource("blacklist-item")
  */
-class BlacklistItemController extends AbstractRestController implements ClassResourceInterface
+class BlacklistItemController extends AbstractRestController
 {
     use RequestParametersTrait;
 

--- a/Resources/config/routing_api.yaml
+++ b/Resources/config/routing_api.yaml
@@ -1,3 +1,55 @@
-sulu_community.blacklist_item:
-    type: rest
-    resource: sulu_community.controller.blacklist_item
+sulu_community.fields_blacklist-item:
+    path: '/blacklist-items/fields.{_format}'
+    methods: GET
+    controller: 'sulu_community.controller.blacklist_item::fieldsAction'
+    format: json
+    defaults: { _format: json }
+    requirements: { _format: json|csv }
+
+sulu_community.get_blacklist-items:
+    path: '/blacklist-items.{_format}'
+    methods: GET
+    controller: 'sulu_community.controller.blacklist_item::cgetAction'
+    format: json
+    defaults: { _format: json }
+    requirements: { _format: json|csv }
+
+sulu_community.get_blacklist-item:
+    path: '/blacklist-items/{id}.{_format}'
+    methods: GET
+    controller: 'sulu_community.controller.blacklist_item::getAction'
+    format: json
+    defaults: { _format: json }
+    requirements: { _format: json|csv }
+
+sulu_community.post_blacklist-item:
+    path: '/blacklist-items.{_format}'
+    methods: POST
+    controller: 'sulu_community.controller.blacklist_item::postAction'
+    format: json
+    defaults: { _format: json }
+    requirements: { _format: json|csv }
+
+sulu_community.delete_blacklist-item:
+    path: '/blacklist-items/{id}.{_format}'
+    methods: DELETE
+    controller: 'sulu_community.controller.blacklist_item::deleteAction'
+    format: json
+    defaults: { _format: json }
+    requirements: { _format: json|csv }
+
+sulu_community.delete_blacklist-items:
+    path: '/blacklist-items.{_format}'
+    methods: DELETE
+    controller: 'sulu_community.controller.blacklist_item::cdeleteAction'
+    format: json
+    defaults: { _format: json }
+    requirements: { _format: json|csv }
+
+sulu_community.put_blacklist-item:
+    path: '/blacklist-items/{id}.{_format}'
+    methods: PUT
+    controller: 'sulu_community.controller.blacklist_item::putAction'
+    format: json
+    defaults: { _format: json }
+    requirements: { _format: json|csv }

--- a/Resources/doc/1-installation.md
+++ b/Resources/doc/1-installation.md
@@ -40,7 +40,6 @@ Register the admin routes:
 # config/routes/sulu_community_admin.yaml
 
 sulu_community_api:
-    type: rest
     resource: "@SuluCommunityBundle/Resources/config/routing_api.yaml"
     prefix: /admin/api
 ```

--- a/Tests/Application/config/routing_admin.yml
+++ b/Tests/Application/config/routing_admin.yml
@@ -1,4 +1,3 @@
 sulu_community_api:
-    type: rest
     prefix:  /admin/api
     resource: "@SuluCommunityBundle/Resources/config/routing_api.yaml"

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,22 @@
 
 ## 2.0.0 (unreleased)
 
+### FOSRestRouting Bundle removed
+
+As announced in Sulu [2.6.10](https://github.com/sulu/sulu/blob/2.6/UPGRADE-2.x.md)
+the `type: rest` / [FOSRestRouting](https://github.com/handcraftedinthealps/RestRoutingBundle) was removed.
+
+The following change is needed in your application:
+
+```diff
+# config/routes/sulu_community_admin.yaml
+
+sulu_community_api:
+-    type: rest
+     resource: "@SuluCommunityBundle/Resources/config/routing_api.yaml"
+     prefix:   /admin/api
+```
+
 ### ListRepresentation relation name changed
 
 The name of the relation inside of the `_embedded` field has been changed from `items` to `blacklist_items`.


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | sulu/sulu#7434
| License | MIT

#### What's in this PR?
Replacing rest routing with Symfony routing.

Other stuff needed to fix the pipeline:
- phpstan baseline update
- phpcs changes

#### Why?
It's not part of sulu anymore and will be removed in 3.0 anyways.