### PR TITLE
Fix MailFactory from email + name

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -22,7 +22,8 @@ jobs:
                     - php-version: '7.2'
                       lint: false
                       dependency-versions: 'lowest'
-                      tools: 'composer:v1'
+                      tools: 'composer:v2'
+                      composer-block-insecure: false
                       env:
                           SYMFONY_DEPRECATIONS_HELPER: disabled
 
@@ -30,6 +31,7 @@ jobs:
                       lint: false
                       dependency-versions: 'highest'
                       tools: 'composer:v2'
+                      composer-block-insecure: false
                       env:
                           SYMFONY_DEPRECATIONS_HELPER: weak
 
@@ -79,6 +81,10 @@ jobs:
                   php-version: ${{ matrix.php-version }}
                   extensions: 'mysql, gd'
                   tools: ${{ matrix.tools }}
+
+            - name: Set composer block-insecure
+              if: ${{ matrix.composer-block-insecure == false }}
+              run: composer config "audit.block-insecure" false
 
             - name: Remove php-cs-fixer/shim package
               if: ${{ matrix.php-version == '7.2' }}

--- a/Mail/MailFactory.php
+++ b/Mail/MailFactory.php
@@ -118,7 +118,8 @@ class MailFactory implements MailFactoryInterface
             if (empty($address)) {
                 return null;
             } elseif (!isset($address['email'])) {
-                $email = $address[\array_keys($address)[0]];
+                $email = \array_keys($address)[0];
+                $name = $address[\array_keys($address)[0]];
             } else {
                 $email = $address['email'];
                 $name = $address['name'] ?? '';


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Fix the way the from email/name is accessed in the Mailfactory.

The configuration looks like this 

```yaml
sulu_community:
    webspaces:
        test:
            from:
                name: "Test"
                email: "test@test.at"
```

And [ $from](https://github.com/sulu/SuluCommunityBundle/blob/2.0/EventListener/MailListener.php#L111) is an array like `[test@test.at => Test]` [see](https://github.com/sulu/SuluCommunityBundle/blob/2.0/DependencyInjection/CompilerPass/CommunityManagerCompilerPass.php#L126).


